### PR TITLE
docs: reorder Core Concepts to match intro

### DIFF
--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -10,7 +10,6 @@ Revisium is built on a set of foundational concepts that work together: a hierar
 
 | Concept | What it does |
 |---------|-------------|
-| [Platform Hierarchy](./platform-hierarchy) | Organization → Project → Branch → Revision → Table → Row |
 | [Data Modeling](./data-modeling) | Define field types, nesting, constraints for every table |
 | [Foreign Keys](./foreign-keys) | Referential integrity between tables with cascade operations |
 | [Computed Fields](./computed-fields) | Formula expressions (`x-formula`) with 40+ built-in functions |
@@ -18,5 +17,6 @@ Revisium is built on a set of foundational concepts that work together: a hierar
 | [Versioning](./versioning) | Draft → commit → HEAD workflow with full history and diff |
 | [Branches](./branches) | Isolated development lines within a project |
 | [Schema Evolution](./schema-evolution) | Change types, add/remove fields — data transforms automatically |
+| [Platform Hierarchy](./platform-hierarchy) | Organization → Project → Branch → Revision → Table → Row |
 
 These concepts combine to provide a platform where schema defines structure, foreign keys enforce relationships, versioning tracks history, and APIs are generated automatically from whatever you build.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -17,7 +17,6 @@ const sidebars: SidebarsConfig = {
         id: "core-concepts/index",
       },
       items: [
-        "core-concepts/platform-hierarchy",
         "core-concepts/data-modeling",
         "core-concepts/foreign-keys",
         "core-concepts/computed-fields",
@@ -25,6 +24,7 @@ const sidebars: SidebarsConfig = {
         "core-concepts/versioning",
         "core-concepts/branches",
         "core-concepts/schema-evolution",
+        "core-concepts/platform-hierarchy",
       ],
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reordered Core Concepts to match the intro page: moved “Platform Hierarchy” to the end in the docs index and `sidebars.ts` for consistent navigation.

<sup>Written for commit d5ae0fea214c73e6ed0473959dbf5c1a4b6c6556. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

