### PR TITLE
fix: nginx — serve static HTML directly, avoid SPA flash

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ server {
     if ( $uri = '/index.html' ) {
       add_header Cache-Control no-store always;
     }
-    try_files $uri /index.html;
+    try_files $uri $uri/ $uri/index.html /index.html;
     expires off;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Nginx try_files to check $uri, $uri/, and $uri/index.html before falling back to /index.html. This serves existing static HTML directly and removes the SPA flash on first load and deep links.

<sup>Written for commit cae15e2f6865e7cb0375803aae8246fda91ebc5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

