### PR TITLE
fix: nginx — restore direct link support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,12 +3,13 @@ server {
   listen   [::]:8080;
 
   root /usr/share/nginx/html;
+  index index.html;
 
   location / {
     if ( $uri = '/index.html' ) {
       add_header Cache-Control no-store always;
     }
-    try_files $uri $uri/ $uri/index.html /index.html;
+    try_files $uri $uri/index.html /index.html;
     expires off;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore direct link support in Nginx for SPA routes by serving index.html as the default and avoiding directory redirects. Deep links now resolve correctly without 301s or 404s by adding index index.html and updating try_files to: $uri $uri/index.html /index.html.

<sup>Written for commit b472e42ab7df4399b5483c7db64651b2f15ca74a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

