### PR TITLE
docs: platform hierarchy, links underline, scroll, intro fixes

### DIFF
--- a/docs/core-concepts/platform-hierarchy.md
+++ b/docs/core-concepts/platform-hierarchy.md
@@ -6,10 +6,10 @@ import Screenshot from '@site/src/components/Screenshot';
 
 # Platform Hierarchy
 
-Revisium organizes data in a hierarchy inspired by Git.
+Revisium organizes data in a hierarchy inspired by GitHub:
 
 ```
-Organization
+Organization (= username)
   └── Project
         └── Branch (master, staging, dev)
               └── Revision (immutable snapshot) / Draft (WIP)
@@ -17,21 +17,25 @@ Organization
                           └── Row (id + data)
 ```
 
-## Analogy with Git
+## Analogy with GitHub
 
-| Revisium | Git | Description |
-|----------|-----|-------------|
-| Organization | GitHub Org | Top-level container, groups projects |
-| Project | Repository | Independent data space with its own schema |
+| Revisium | GitHub | Description |
+|----------|--------|-------------|
+| Organization | GitHub Org / User | Top-level namespace |
+| Project | Repository | Independent data space with tables, branches, and endpoints |
 | Branch | Branch | Isolated development line |
 | Revision | Commit | Immutable snapshot of all tables and rows |
 | Draft | Working directory | Mutable state where changes are made |
-| Table | File | Data structure defined by JSON Schema |
-| Row | Content | A data record with a unique `id` within a table |
+| Table | Folder | Collection of records sharing the same schema |
+| Row | File in folder | A data record with a unique `id`, conforming to the table's schema |
 
 ## Organization
 
-The top-level container. Each organization has members with roles (admin, editor, viewer). An organization owns one or more projects.
+The top-level namespace. Your username is your organization — they are the same thing. Each organization owns one or more projects and has members with roles (admin, editor, viewer).
+
+:::note Limitation
+Currently, you cannot create separate organizations. Your username acts as your single organization. Multi-organization support is planned.
+:::
 
 ## Project
 
@@ -44,25 +48,19 @@ Projects are isolated — schemas and data don't leak between projects.
 
 ## Branch
 
-Each branch has its own revision history and a current draft. Changes on one branch don't affect others.
-
-Use cases for branches:
-- `master` — production data
-- `staging` — pre-release review
-- `dev` — development and experimentation
-- Feature branches for A/B testing or per-client configurations
+Each branch has its own revision history and a current draft. Changes on one branch don't affect others. See [Versioning & Branches](./versioning#branches) for details.
 
 ## Revision and Draft
 
 A **revision** is an immutable, point-in-time snapshot of every table and row in a branch. Once committed, a revision cannot be changed.
 
-A **draft** is the mutable working state. All modifications (create, update, delete tables and rows) happen in the draft. When ready, the draft is committed to produce a new revision.
+A **draft** is the mutable working state. All modifications happen in the draft. When ready, the draft is committed to produce a new revision.
 
 ```
 Draft (mutable) → commit → Revision (immutable) = new HEAD
 ```
 
-The **HEAD** revision is the latest committed state of a branch.
+See [Versioning & Branches](./versioning) for the full commit workflow, diff, and rollback.
 
 ## Table
 
@@ -72,6 +70,4 @@ A table is defined by a [JSON Schema](./data-modeling) and contains rows. Tables
 
 A row is a data record identified by a unique string `id` within a table. The row data must conform to the table's JSON Schema.
 
-System fields (`createdAt`, `updatedAt`, `hash`, etc.) are stored separately from user data and can be optionally included in the schema via `$ref`.
-
-<Screenshot alt="Admin UI — project with tables, branch selector, and revision info in the sidebar" />
+System fields (`createdAt`, `updatedAt`, `hash`, etc.) are stored separately from user data and can be optionally included in the schema via `$ref`. See [System Fields](./data-modeling#system-fields).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -274,7 +274,7 @@ S3 file attachments at any schema level — images, documents, galleries. Use em
 
 [Learn more →](./core-concepts/files)
 
-### Versioning
+### Versioning & Branches
 
 Not row-level versioning. Not table-level versioning. **Project-level versioning** — one commit captures a full snapshot of all tables, schemas, and data.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -54,6 +54,9 @@
   /* Sidebar */
   --doc-sidebar-width: 260px;
 
+  /* Scroll */
+  scroll-behavior: smooth;
+
   /* Content area */
   --ifm-line-height-base: 1.65;
   --ifm-leading: 1.25rem;
@@ -274,6 +277,10 @@
 [data-theme="dark"] .markdown ul,
 [data-theme="dark"] .markdown ol {
   color: #737373;
+}
+
+.markdown a {
+  text-decoration: underline;
 }
 
 .markdown p {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies Platform Hierarchy with a GitHub analogy and clearer terms (org = username namespace — single org for now; project = repo with tables/branches/endpoints; table = folder; row = file). Adds cross-links to Versioning & Branches and System Fields, updates the Intro title to "Versioning & Branches", and improves docs UX by underlining links in content and enabling smooth scrolling.

<sup>Written for commit 6f28cd9f8788490e6408ffbb10343aaf77ac1450. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

