### PR TITLE
feat: theme

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -28,6 +28,8 @@ const config: Config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
+  clientModules: ["./src/theme/colorModeSync.js"],
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/src/theme/colorModeSync.js
+++ b/src/theme/colorModeSync.js
@@ -1,0 +1,51 @@
+const COOKIE_NAME = 'revisium-theme'
+const COOKIE_DOMAIN = '.revisium.io'
+const COOKIE_MAX_AGE = 365 * 24 * 60 * 60
+const COOKIE_REGEX = new RegExp(`(?:^|; )${COOKIE_NAME}=([^;]*)`)
+
+function getThemeFromCookie() {
+  const match = COOKIE_REGEX.exec(document.cookie)
+
+  return match ? match[1] : undefined
+}
+
+function setThemeCookie(theme) {
+  const isLocalhost = globalThis.location.hostname === 'localhost'
+  const domain = isLocalhost ? '' : `; domain=${COOKIE_DOMAIN}`
+
+  document.cookie = `${COOKIE_NAME}=${theme}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax${domain}`
+}
+
+let observerStarted = false
+
+export function onRouteDidUpdate() {
+  // Sync cookie → Docusaurus on load
+  const cookieTheme = getThemeFromCookie()
+
+  if (cookieTheme) {
+    const currentTheme = document.documentElement.dataset.theme
+
+    if (cookieTheme !== currentTheme) {
+      document.documentElement.dataset.theme = cookieTheme
+      localStorage.setItem('theme', cookieTheme)
+    }
+  }
+
+  // Watch for theme changes and sync to cookie (once)
+  if (!observerStarted) {
+    observerStarted = true
+
+    const observer = new MutationObserver(() => {
+      const theme = document.documentElement.dataset.theme
+
+      if (theme) {
+        setThemeCookie(theme)
+      }
+    })
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    })
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sync the site theme across revisium.io using a `revisium-theme` cookie. Applies the cookie theme on navigation and persists changes to the cookie and `localStorage`.

- **New Features**
  - Registered `./src/theme/colorModeSync.js` via `clientModules` to sync with the `revisium-theme` cookie.
  - On route updates, apply cookie to `data-theme` and `localStorage`; observe `data-theme` and write a 1‑year `SameSite=Lax` cookie on `.revisium.io` (no domain on localhost).

<sup>Written for commit 303275a5af5847a0fd994170b2f2d5e721c9a14f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

