### PR TITLE
feat: add Umami analytics

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -28,6 +28,17 @@ const config: Config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
+  headTags: [
+    {
+      tagName: "script",
+      attributes: {
+        defer: "true",
+        src: "https://a.revisium.io/s.js",
+        "data-website-id": "52ce4d21-f6c7-42c1-ad6f-05094c66a264",
+      },
+    },
+  ],
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Umami analytics by injecting a deferred script via Docusaurus `headTags`. Loads `https://a.revisium.io/s.js` with `data-website-id` to track page views without blocking render.

<sup>Written for commit d288001fd72ed5e6071074f644364eec86c62470. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

