### PR TITLE
docs: X-Api-Key header

### DIFF
--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -40,15 +40,15 @@ revisium://localhost:8080/admin/my-project/master?token=eyJ...
 When connecting to a Revisium instance, the CLI supports multiple auth methods:
 
 - **Token** — paste a JWT from the Admin UI (Settings > Get Token)
-- **API Key** — paste a personal API key (`rev_...`) — recommended for repeated local use
+- **API Key** — paste a personal or service API key (`rev_...`). Sends via `X-Api-Key` header. Recommended for programmatic and repeated local use.
 - **Username & Password** — enter credentials directly or set via env vars
 
 ```bash
 # JWT token
 revisium://localhost:9222/admin/my-project/master?token=eyJ...
 
-# API key (same parameter, auto-detected by rev_ prefix)
-revisium://localhost:9222/admin/my-project/master?token=rev_xxxxxxxxxxxxxxxxxxxx
+# API key (via apikey parameter or auto-detected by rev_ prefix in token)
+revisium://localhost:9222/admin/my-project/master?apikey=rev_xxxxxxxxxxxxxxxxxxxx
 ```
 
 ### Environment Variables
@@ -58,7 +58,8 @@ Instead of `--url`, set these:
 | Variable | Description |
 |----------|-------------|
 | `REVISIUM_URL` | Default connection URL |
-| `REVISIUM_TOKEN` | JWT token or API key (`rev_...`) |
+| `REVISIUM_TOKEN` | JWT token |
+| `REVISIUM_API_KEY` | API key (`rev_...`) — sends via `X-Api-Key` header |
 | `REVISIUM_USERNAME` | Username (for auto-login) |
 | `REVISIUM_PASSWORD` | Password (for auto-login) |
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add API Keys authentication across docs and examples. Introduces `X-Api-Key` support, a new API Keys guide, CLI updates (personal/service keys), and deployment settings.

- **New Features**
  - New page: API Keys (personal and service), scoping, create via UI/GraphQL, revoke/rotate, Swagger/Apollo usage, best practices.
  - System and Generated APIs docs: examples for `X-Api-Key` and `Authorization: Bearer rev_...`; public vs private behavior clarified.
  - CLI: API keys via `apikey` URL param or `rev_` token detection; sends via `X-Api-Key`; accepts personal/service keys; added `REVISIUM_API_KEY`.
  - Deployment: added `INTERNAL_API_KEY_ENDPOINT`, `API_KEY_DEFAULT_EXPIRATION_DAYS`, and limits; deprecated `CORE_API_USERNAME`/`CORE_API_PASSWORD` in favor of internal API key.
  - Navigation and assets: sidebar entry added; screenshots for Swagger and Apollo header setup.

- **Migration**
  - Clients should send `X-Api-Key: rev_...` (or `Authorization: Bearer rev_...`) for programmatic access.
  - For CLI, use `REVISIUM_API_KEY` for API keys and keep `REVISIUM_TOKEN` for JWT; or pass `?apikey=rev_...` in the URL.
  - In microservice mode, prefer `INTERNAL_API_KEY_ENDPOINT` over `CORE_API_USERNAME`/`CORE_API_PASSWORD`.

<sup>Written for commit 46fd39f5b4309ac2fc410f2a65f9886ae24e411a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

