### PR TITLE
Fix docs search same-origin fallback

### DIFF
--- a/src/components/search/config.ts
+++ b/src/components/search/config.ts
@@ -9,16 +9,46 @@ export type SearchConfig = {
 };
 
 const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+const SEARCH_ONLY_API_KEY =
+  "3fb8239aac050d830941b71b38063fe9a7af3dec16ac4a7a3369e554dd5ab7d9";
 
-const LOCALHOST_FALLBACK_CONFIG: SearchConfig = {
-  enabled: true,
-  apiKey: "3fb8239aac050d830941b71b38063fe9a7af3dec16ac4a7a3369e554dd5ab7d9",
-  collectionName: "revisium_docs",
-  path: "/search",
-  host: "docs.revisium.io",
-  port: 443,
-  protocol: "https",
-};
+function getLocationProtocol(): "http" | "https" {
+  return globalThis.location.protocol === "https:" ? "https" : "http";
+}
+
+function getLocationPort(protocol: "http" | "https"): number {
+  if (globalThis.location.port.length > 0) {
+    return Number(globalThis.location.port);
+  }
+
+  return protocol === "https" ? 443 : 80;
+}
+
+function buildSameOriginFallbackConfig(): SearchConfig {
+  const protocol = getLocationProtocol();
+
+  return {
+    enabled: true,
+    apiKey: SEARCH_ONLY_API_KEY,
+    collectionName: "revisium_docs",
+    path: "/search",
+    host: globalThis.location.hostname,
+    port: getLocationPort(protocol),
+    protocol,
+  };
+}
+
+function buildLocalhostFallbackConfig(): SearchConfig {
+  return {
+    enabled: true,
+    apiKey: SEARCH_ONLY_API_KEY,
+    collectionName: "revisium_docs",
+    path: "/search",
+    host: "docs.revisium.io",
+    port: 443,
+    protocol: "https",
+  };
+}
 
 function isSearchConfig(value: unknown): value is SearchConfig {
   if (!value || typeof value !== "object") {
@@ -67,9 +97,9 @@ export async function loadSearchConfig(): Promise<SearchConfig> {
     );
   } catch (error) {
     if (LOCALHOST_HOSTNAMES.has(globalThis.location.hostname)) {
-      return LOCALHOST_FALLBACK_CONFIG;
+      return buildLocalhostFallbackConfig();
     }
 
-    throw error;
+    return buildSameOriginFallbackConfig();
   }
 }

--- a/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -10,12 +10,23 @@ type SearchNavbarItemProps = {
 };
 
 type SearchNavbarItemPropsReadonly = Readonly<SearchNavbarItemProps>;
+type SearchHit = {
+  url?: string;
+  url_without_anchor?: string;
+  url_without_variables?: string;
+  __docsearch_parent?: SearchHit;
+};
 
 const DEFAULT_HTTPS_PORT = 443;
 const DEFAULT_HTTP_PORT = 80;
 const SEARCH_QUERY_BY =
   "hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content";
 const SEARCH_QUERY_BY_WEIGHTS = "8,7,6,5,4,3,2,1";
+const SEARCH_RESULT_URL_FIELDS = [
+  "url",
+  "url_without_anchor",
+  "url_without_variables",
+] as const;
 
 function getWindowProtocol(): "http" | "https" {
   return globalThis.location.protocol === "https:" ? "https" : "http";
@@ -47,6 +58,33 @@ function toServerNode(config: SearchConfig): {
     protocol,
     path: config.path,
   };
+}
+
+function rewriteToCurrentOrigin(url: string): string {
+  const nextUrl = new URL(url);
+
+  nextUrl.protocol = globalThis.location.protocol;
+  nextUrl.host = globalThis.location.host;
+
+  return nextUrl.toString();
+}
+
+function rewriteSearchHit(item: SearchHit): SearchHit {
+  const rewrittenItem = { ...item };
+
+  for (const field of SEARCH_RESULT_URL_FIELDS) {
+    if (typeof rewrittenItem[field] === "string") {
+      rewrittenItem[field] = rewriteToCurrentOrigin(rewrittenItem[field]);
+    }
+  }
+
+  if (rewrittenItem.__docsearch_parent) {
+    rewrittenItem.__docsearch_parent = rewriteSearchHit(
+      rewrittenItem.__docsearch_parent,
+    );
+  }
+
+  return rewrittenItem;
 }
 
 export default function SearchNavbarItem({
@@ -87,6 +125,7 @@ export default function SearchNavbarItem({
             per_page: 8,
             prioritize_exact_match: true,
           },
+          transformItems: (items: SearchHit[]) => items.map(rewriteSearchHit),
         });
 
         if (!disposed) {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs search to fall back to same-origin `/search` when `/search-config.json` is missing. Keeps the search UI visible and ensures result links stay on the current domain.

- **Bug Fixes**
  - Build runtime same-origin fallback config using `location` (protocol, host, port).
  - Keep localhost fallback to `docs.revisium.io` for local dev.
  - Always send search requests to current-origin `/search`.
  - Rewrite result URLs (including nested `__docsearch_parent`) to the current origin.
  - Keep the search button visible if config loading fails.

<sup>Written for commit 671e8a017c9ce6c20d7372114a3391c60b7d25e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

