### PR TITLE
[codex] Test docs release 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@docusaurus/core": "3.8.1",
         "@docusaurus/preset-classic": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

Bumps the docs package metadata from `0.1.1` to `0.1.2` to test the merged `revisium-actions@v0.1.0` release metadata integration.

## Expected GitHub behavior

- PR CI runs against the version bump.
- After merge to `master`, `release.yml` validates package metadata through `revisium-actions`.
- If validation passes, `release.yml` creates tag `v0.1.2`.
- The tag push then exercises the docs build workflow.

## Local validation

- `npm run typecheck`
- `TARGET_VERSION=0.1.2 node ../revisium-actions/bin/validate-version-metadata.mjs`
- `TARGET_VERSION=0.1.2 node ../revisium-actions/bin/check-prerelease-deps.mjs`
- `git diff --check`
- `npm run build`

Note: Docusaurus build succeeds but prints the existing local update-check config warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->