### PR TITLE
Add release train dry run

### DIFF
--- a/.github/workflows/release-train-dry-run.yml
+++ b/.github/workflows/release-train-dry-run.yml
@@ -1,0 +1,42 @@
+name: Release Train Dry Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Release train transition to validate without pushing.
+        required: true
+        default: start-minor-alpha
+        type: choice
+        options:
+          - start-minor-alpha
+          - start-major-alpha
+          - start-minor-rc
+          - start-major-rc
+          - start-minor-stable
+          - start-major-stable
+          - alpha-bump
+          - promote-rc
+          - rc-bump
+          - stable
+          - patch
+          - patch-alpha-start
+          - patch-rc-start
+
+permissions:
+  contents: read
+
+jobs:
+  release-train:
+    name: Plan release train
+    uses: revisium/revisium-actions/.github/workflows/release-train.yml@5bd118f409d299aeab62051d64176c40f5a75933 # v0.2.0
+    with:
+      action: ${{ inputs.action }}
+      dry_run: true
+      actions_ref: 5bd118f409d299aeab62051d64176c40f5a75933 # v0.2.0
+      base_branch: master
+      node_version: 22.11.0
+      install_command: npm ci
+      validate_command: |
+        npm run typecheck
+        npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,13 @@ jobs:
 
       - name: Validate release metadata
         if: ${{ steps.check_bump.outputs.bumped == 'true' }}
-        uses: revisium/revisium-actions/actions/validate-version-metadata@e6f4d30d4bd90adf706a21c541a176521ff35971 # v0.1.0
+        uses: revisium/revisium-actions/actions/validate-version-metadata@5bd118f409d299aeab62051d64176c40f5a75933 # v0.2.0
         with:
           target-version: ${{ steps.check_bump.outputs.version }}
 
       - name: Check prerelease runtime dependencies
         if: ${{ steps.check_bump.outputs.bumped == 'true' }}
-        uses: revisium/revisium-actions/actions/check-prerelease-deps@e6f4d30d4bd90adf706a21c541a176521ff35971 # v0.1.0
+        uses: revisium/revisium-actions/actions/check-prerelease-deps@5bd118f409d299aeab62051d64176c40f5a75933 # v0.2.0
         with:
           target-version: ${{ steps.check_bump.outputs.version }}
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Revisium Docs
+
+## Release Train Dry Run
+
+Use the `Release Train Dry Run` workflow to validate release-train transitions
+without pushing branches, commits, tags, or releases.
+
+Manual dispatch:
+
+1. Open **Actions** -> **Release Train Dry Run**.
+2. Select the release transition, for example `start-minor-alpha`.
+3. Run the workflow from `master` for `start-*` transitions, or from the
+   matching `release/X.Y.x` branch for branch-scoped transitions.
+
+Bot dispatch can call the same `workflow_dispatch` endpoint with the `action`
+input. The workflow is pinned to `revisium-actions` `v0.2.0` by commit hash and
+passes `dry_run: true`, so it only reports the planned target branch, version,
+tag, and channel.


### PR DESCRIPTION
## Summary

- add a manual Release Train Dry Run workflow pinned to revisium-actions v0.2.0 by commit hash
- run docs release planning in dry-run mode with npm ci, typecheck, and build validation
- update existing release metadata checks from revisium-actions v0.1.0 to v0.2.0
- document manual and bot workflow_dispatch usage in README

## Validation

- npx prettier --check .github/workflows/release-train-dry-run.yml .github/workflows/release.yml README.md
- RELEASE_ACTION=start-minor-alpha BASE_BRANCH=master CURRENT_BRANCH=master DRY_RUN=true PACKAGE_PATH=package.json node /Users/anton/projects/revisium/revisium-actions/bin/plan-release.mjs
- npm ci
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Release Train Dry Run workflow for manually testing release-transition operations in dry-run mode, reporting planned outcomes without applying changes.

* **Documentation**
  * Added documentation explaining the Release Train Dry Run workflow and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->