### PR TITLE
Update release train pin to v0.3.1

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   release-train:
     name: Release train
-    uses: revisium/revisium-actions/.github/workflows/release-train.yml@3acf688c2c435b5049f891de670a8b3adbbe47bb # v0.3.0
+    uses: revisium/revisium-actions/.github/workflows/release-train.yml@d79f100673a30455c79042669757b48322ce436f # v0.3.1
     with:
       action: ${{ inputs.action }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -29,6 +29,7 @@ on:
         type: boolean
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Manual dispatch:
    matching `release/X.Y.x` branch for branch-scoped transitions.
 
 Bot dispatch can call the same `workflow_dispatch` endpoint with the `action`
-and `dry_run` inputs. The workflow is pinned to `revisium-actions` `v0.3.0` by
+and `dry_run` inputs. The workflow is pinned to `revisium-actions` `v0.3.1` by
 commit hash.
 
 Write mode requires these repository settings:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflow to version 0.3.1
  * Enhanced workflow permissions configuration to include actions access
  * Updated documentation to reflect current workflow versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->