### PR TITLE
Refactor docs workflows onto revisium-actions v0.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,36 +9,16 @@ on:
     tags:
       - "*"
 
-env:
-  IMAGE_NAME: ${{ github.event.repository.name }}
+permissions:
+  contents: read
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@763f2746000f15842e642130dba3acf09c5d00ac # v0.3.2
+    with:
+      image_name: ${{ github.event.repository.name }}
+      context: .
+      dockerfile: Dockerfile
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,29 +7,26 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    uses: revisium/revisium-actions/.github/workflows/node-build.yml@763f2746000f15842e642130dba3acf09c5d00ac # v0.3.2
+    with:
+      node_version: 22.11.0
+      install_command: npm ci
+      run_commands: npm run typecheck
 
-    defaults:
-      run:
-        shell: bash
+  sonar:
+    needs: checks
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22.11.0
-          cache: "npm"
-          cache-dependency-path: ./package-lock.json
-
-      - run: npm ci
-      - run: npm run typecheck
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   release-train:
     name: Release train
-    uses: revisium/revisium-actions/.github/workflows/release-train.yml@d79f100673a30455c79042669757b48322ce436f # v0.3.1
+    uses: revisium/revisium-actions/.github/workflows/release-train.yml@763f2746000f15842e642130dba3acf09c5d00ac # v0.3.2
     with:
       action: ${{ inputs.action }}
       dry_run: ${{ inputs.dry_run }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Manual dispatch:
 
 Bot dispatch can call the same `workflow_dispatch` endpoint with the `action`
 and `dry_run` inputs. The release-train, CI, and Docker build workflows are
-pinned to `revisium-actions` `v0.3.2` by commit hash.
+pinned to `revisium-actions` `v0.3.2` by commit hash `763f2746`.
 
 Write mode requires these repository settings:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Manual dispatch:
    matching `release/X.Y.x` branch for branch-scoped transitions.
 
 Bot dispatch can call the same `workflow_dispatch` endpoint with the `action`
-and `dry_run` inputs. The workflow is pinned to `revisium-actions` `v0.3.1` by
+and `dry_run` inputs. The workflow is pinned to `revisium-actions` `v0.3.2` by
 commit hash.
 
 Write mode requires these repository settings:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Manual dispatch:
    matching `release/X.Y.x` branch for branch-scoped transitions.
 
 Bot dispatch can call the same `workflow_dispatch` endpoint with the `action`
-and `dry_run` inputs. The workflow is pinned to `revisium-actions` `v0.3.2` by
-commit hash.
+and `dry_run` inputs. The release-train, CI, and Docker build workflows are
+pinned to `revisium-actions` `v0.3.2` by commit hash.
 
 Write mode requires these repository settings:
 


### PR DESCRIPTION
## Summary
- pin the docs release-train workflow to revisium-actions v0.3.2 commit 763f2746
- refactor Client CI onto the reusable node-build workflow while keeping Sonar scan local
- refactor Docker image build onto the reusable docker-build workflow with explicit DockerHub secrets
- update the docs README version and pinned commit note

## Validation
- npx prettier .github/workflows/ci.yml .github/workflows/build.yml .github/workflows/release-train.yml README.md --check
- npx prettier README.md --check
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to call newer reusable workflow versions and added top-level permissions where required.
  * Replaced inline build and check steps with reusable workflow invocations for build, Docker image publishing, and node checks.
* **Documentation**
  * Updated README release-train section to reference the new pinned workflow version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->