### PR TITLE
docs: update release 001 auth and storage docs

### DIFF
--- a/docs/apis/configuration.md
+++ b/docs/apis/configuration.md
@@ -12,42 +12,47 @@ Control which type variants are generated:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENDPOINT_GRAPHQL_SHOW_NODE_TYPE` | `true` | Generate Node types (with metadata) |
-| `ENDPOINT_GRAPHQL_SHOW_FLAT_TYPE` | `true` | Generate Flat types (data only) |
+| `GRAPHQL_HIDE_NODE_TYPES` | `false` | Hide generated node types from GraphQL query fields |
+| `GRAPHQL_HIDE_FLAT_TYPES` | `false` | Hide generated flat data types from GraphQL query fields |
 
-Set to `false` to hide a type variant from the generated schema. Useful for public APIs where you only want Flat types.
+Set a flag to `true` or `1` to hide that type variant from the generated query schema. This is useful for public APIs where you only want flat data types, or internal APIs where you want the node shape with full metadata.
+
+When using draft endpoints, singular mutations can still return node types even if `GRAPHQL_HIDE_NODE_TYPES=true`, because mutations need a stable return type. The hide flags primarily control query-field visibility.
 
 ## Naming
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENDPOINT_GRAPHQL_ADD_PROJECT_PREFIX` | `true` | Prefix type names with project name |
+| `GRAPHQL_PREFIX_FOR_TABLES` | project name | Prefix for table-specific GraphQL types. Set to an empty string to remove the project prefix |
+| `GRAPHQL_PREFIX_FOR_COMMON` | project name | Prefix for shared GraphQL types such as filters and pagination types. Set to an empty string to remove the project prefix |
+| `GRAPHQL_FLAT_POSTFIX` | `Flat` | Postfix for flat GraphQL types |
+| `GRAPHQL_NODE_POSTFIX` | empty | Postfix inserted before node type suffixes |
 
-When `true`, types are named `{Project}{Table}` (e.g., `BlogPost`). When `false`, types use only the table name (e.g., `Post`). Disable the prefix when each endpoint serves a single project and you want cleaner type names.
+By default, generated table types are named from the project and table, for example `BlogPost`, `BlogPostNode`, and `BlogPostFlat`. Use empty prefixes when each endpoint serves a single project and you want shorter names.
+
+Do not set both `GRAPHQL_FLAT_POSTFIX` and `GRAPHQL_NODE_POSTFIX` to empty strings when `GRAPHQL_HIDE_NODE_TYPES=false` and `GRAPHQL_HIDE_FLAT_TYPES=false`. Hide one type variant first, or keep at least one postfix non-empty.
 
 ## Federation
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ENDPOINT_GRAPHQL_FEDERATION` | `false` | Enable Apollo Federation support |
+Generated GraphQL node types include Apollo Federation metadata with the `@key` directive. There is no separate federation feature flag; use the naming variables above when you need stable type names for gateway composition.
 
-When enabled, generated schemas include Federation directives for use in a federated gateway.
-
-## Performance
+## Mutations
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENDPOINT_MAX_QUERY_DEPTH` | `10` | Maximum GraphQL query depth |
-| `ENDPOINT_MAX_QUERY_COMPLEXITY` | `1000` | Maximum query complexity score |
+| `GRAPHQL_HIDE_MUTATIONS` | `false` | Hide generated GraphQL mutations from draft revision schemas |
+
+Generated GraphQL mutations are only exposed for draft revisions. Head revisions are read-only regardless of this setting. Set `GRAPHQL_HIDE_MUTATIONS=true` when you need a kill switch for generated GraphQL mutations while keeping generated GraphQL query schemas available. REST endpoints are unchanged by this flag.
 
 ## Example Configurations
 
 ### Public API (simplified types)
 
 ```bash
-ENDPOINT_GRAPHQL_SHOW_NODE_TYPE=false
-ENDPOINT_GRAPHQL_SHOW_FLAT_TYPE=true
-ENDPOINT_GRAPHQL_ADD_PROJECT_PREFIX=false
+GRAPHQL_HIDE_NODE_TYPES=true
+GRAPHQL_HIDE_FLAT_TYPES=false
+GRAPHQL_PREFIX_FOR_TABLES=
+GRAPHQL_PREFIX_FOR_COMMON=
 ```
 
 Result: clean types like `Post`, `PostFlat`, `Product` without project prefix or Node types.
@@ -55,18 +60,17 @@ Result: clean types like `Post`, `PostFlat`, `Product` without project prefix or
 ### Admin Interface (full types)
 
 ```bash
-ENDPOINT_GRAPHQL_SHOW_NODE_TYPE=true
-ENDPOINT_GRAPHQL_SHOW_FLAT_TYPE=true
-ENDPOINT_GRAPHQL_ADD_PROJECT_PREFIX=true
+GRAPHQL_HIDE_NODE_TYPES=false
+GRAPHQL_HIDE_FLAT_TYPES=false
+GRAPHQL_HIDE_MUTATIONS=false
 ```
 
-Result: full type variants with project prefix for disambiguation.
+Result: full query type variants with project prefixes for disambiguation, plus draft mutations.
 
-### Microservice (federated)
+### Read-only generated GraphQL
 
 ```bash
-ENDPOINT_GRAPHQL_FEDERATION=true
-ENDPOINT_GRAPHQL_ADD_PROJECT_PREFIX=true
+GRAPHQL_HIDE_MUTATIONS=true
 ```
 
-Result: Federation-ready schema that can be composed with other services in an Apollo Gateway.
+Result: generated queries remain available, but draft-revision mutations are omitted from the schema.

--- a/docs/apis/generated-apis.md
+++ b/docs/apis/generated-apis.md
@@ -250,4 +250,4 @@ REST endpoints include an OpenAPI/Swagger specification with typed request/respo
 
 ## Apollo Federation
 
-GraphQL schemas support Apollo Federation for use in a federated gateway. See [Configuration](./configuration).
+Generated GraphQL node types include Apollo Federation metadata with the `@key` directive for gateway composition. Stable gateway composition depends on the generated type names, so review [Configuration](./configuration) before changing GraphQL naming variables such as prefixes and postfixes.

--- a/docs/auth-permissions/authentication.md
+++ b/docs/auth-permissions/authentication.md
@@ -4,23 +4,87 @@ sidebar_position: 1
 
 # Authentication
 
-## JWT Authentication
+## Browser Session Authentication
 
-The primary authentication method for the Admin UI and System API.
+The Admin UI uses the JWT-based cookie session model. After login, Revisium sets three cookies:
+
+| Cookie | Type | Path | Default lifetime | Purpose |
+|--------|------|------|------------------|---------|
+| `rev_at` | httpOnly JWT access token | `/` | 30 minutes | Authenticates browser requests to core, generated APIs, and the Admin UI backend |
+| `rev_rt` | httpOnly opaque refresh token | `/api/auth/` | 7 days | Rotates the browser session through `/api/auth/refresh` |
+| `rev_session` | readable presence flag | `/` | 7 days | Lets the Admin UI know a session may still be alive; it is not a credential |
+
+`rev_session=1` can outlive `rev_at`. That is expected: the access cookie is short-lived, while the refresh cookie and presence flag use the longer session lifetime. The Admin UI can then refresh the session without storing bearer tokens in `localStorage`.
+
+Cookie `Secure` and `SameSite` attributes are controlled by `COOKIE_SECURE` and `COOKIE_SAMESITE`; proxy and credentialed CORS behavior depends on `TRUST_PROXY` and `CORS_ORIGIN`. See [Deployment authentication](../deployment#authentication).
+
+```mermaid
+sequenceDiagram
+  participant Browser as Admin UI
+  participant Core as Revisium Core
+
+  Browser->>Core: login / OAuth callback
+  Core-->>Browser: Set-Cookie rev_at, rev_rt, rev_session
+  Browser->>Core: authenticated API request with rev_at
+  Core-->>Browser: data
+  Browser->>Core: POST /api/auth/refresh with rev_rt
+  Core-->>Browser: rotated rev_at, rev_rt, rev_session
+  Browser->>Core: POST /api/auth/logout
+  Core-->>Browser: clear rev_at, rev_rt, rev_session
+```
 
 ### Login
+
+The `login` GraphQL mutation still returns an `accessToken` for API clients, but browser login also sets the auth cookies on the response.
 
 ```graphql
 mutation {
   login(data: { username: "admin", password: "admin" }) {
     accessToken
+    expiresIn
   }
 }
 ```
 
-### Using the Token
+### Refresh And Logout
 
-Include the JWT in the `Authorization` header:
+Browser session refresh is cookie-driven:
+
+```bash
+curl -X POST http://localhost:8080/api/auth/refresh \
+  -H "Cookie: rev_rt=<refresh-cookie>" \
+  -i
+```
+
+The refresh endpoint reads only the `rev_rt` cookie; it does not require `rev_at` to be present or valid. This lets the browser recover after the access cookie expires while `rev_session` still exists. On success, Revisium rotates the refresh token and returns new `Set-Cookie` headers for `rev_at`, `rev_rt`, and `rev_session`. Missing, invalid, or expired `rev_rt` clears the browser session cookies and returns unauthorized.
+
+A retry with the same refresh token inside the default 30-second `JWT_REFRESH_GRACE_PERIOD_MS` window is treated as a duplicate refresh attempt. Outside that window, Revisium treats the same token as refresh-token reuse, revokes the refresh-token family, clears the browser session cookies, and rejects the request.
+
+Logout revokes the refresh-token family when possible and clears all three cookies:
+
+```bash
+curl -X POST http://localhost:8080/api/auth/logout \
+  -H "Cookie: rev_rt=<refresh-cookie>" \
+  -i
+```
+
+### `/get-token` And `issueAccessToken`
+
+The Admin UI `/get-token` page calls the GraphQL `issueAccessToken` query from the current browser session:
+
+```graphql
+query {
+  issueAccessToken {
+    accessToken
+  }
+}
+```
+
+Use this when you are already logged in through cookies but need a short-lived bearer token for a CLI, script, or manual API call. `issueAccessToken` only works for JWT-authenticated sessions; API-key-authenticated requests cannot mint a user access token.
+
+## Bearer Token Authentication
+
+Bearer tokens remain supported for programmatic access. Include the JWT in the `Authorization` header:
 
 ```bash
 curl -X POST http://localhost:8080/graphql \
@@ -28,6 +92,8 @@ curl -X POST http://localhost:8080/graphql \
   -H "Authorization: Bearer <accessToken>" \
   -d '{"query": "{ me { id username } }"}'
 ```
+
+For long-lived integrations, prefer API keys over copying a browser-issued access token.
 
 ### Default Credentials
 
@@ -37,7 +103,7 @@ curl -X POST http://localhost:8080/graphql \
 | Standalone (with `--auth`) | `admin` | `admin` |
 | Cloud | Google/GitHub OAuth |
 
-Change the default admin password via the `ADMIN_PASSWORD` environment variable.
+Do not use default credentials outside local development. Set `ADMIN_PASSWORD` before the first Docker or self-hosted start, replace standalone `admin` / `admin` immediately when `--auth` is used, and use OAuth or a secrets manager for production where possible.
 
 ## OAuth 2.1
 
@@ -78,6 +144,8 @@ curl -H "Authorization: Bearer rev_xxxxxxxxxxxxxxxxxxxx" \
 
 ## Session Security
 
-- JWT tokens are stateless — no server-side session storage
+- `rev_at` is stateless; refresh tokens are stored server-side and rotate on refresh
+- `rev_rt` is httpOnly and scoped to `/api/auth/`
+- `rev_session` is readable by the Admin UI but carries only the literal value `1`
 - MCP sessions are isolated — each connection has its own auth state
 - By default, all API endpoints (except login) require authentication. Public projects allow unauthenticated read access to generated endpoints

--- a/docs/core-concepts/data-modeling.md
+++ b/docs/core-concepts/data-modeling.md
@@ -508,5 +508,5 @@ Data modeling defines the structure. On top of it, you can add:
 
 - **[Foreign Keys](./foreign-keys)** — relationships between tables with referential integrity
 - **[Computed Fields](./computed-fields)** — formula-based read-only fields (`x-formula`)
-- **[Files](./files)** — S3 file attachments at any schema level
+- **[Files](./files)** — file attachments at any schema level, backed by local or S3-compatible storage
 - **[Schema Evolution](./schema-evolution)** — change types, add/remove fields with automatic data transforms

--- a/docs/core-concepts/files.md
+++ b/docs/core-concepts/files.md
@@ -9,9 +9,21 @@ import TabItem from '@theme/TabItem';
 
 # Files
 
-Revisium supports file attachments at any level of your schema. Files are stored in S3-compatible storage and managed through the Admin UI or REST API.
+Revisium supports file attachments at any level of your schema. Files can be stored on the local filesystem for standalone or simple single-node deployments, or in S3-compatible storage for production and multi-node deployments.
 
 File fields are like slots in your schema — you define where files go, the platform handles upload, storage, and metadata. Any file type is supported: images, documents, videos, archives, or any other binary. Unopinionated: embed files directly in your tables, create a dedicated assets table, or mix both — structure it however fits your project.
+
+## Storage Providers
+
+| Deployment | Default storage behavior | File URLs |
+|------------|--------------------------|-----------|
+| Standalone | `STORAGE_PROVIDER=local`, `STORAGE_LOCAL_PATH=<data>/uploads` | Served through `PUBLIC_URL/files/...`, for example `http://localhost:9222/files/<hash>` |
+| Self-hosted single node | Set `STORAGE_PROVIDER=local` and `STORAGE_LOCAL_PATH` explicitly if you want local uploads | Served through `FILE_PLUGIN_PUBLIC_ENDPOINT`, defaulting to `http://localhost:{PORT}/files` |
+| Docker/Kubernetes/multi-pod | Set `STORAGE_PROVIDER=s3` explicitly, or leave it unset only when all `S3_*` variables are present so self-hosted S3 autodetection can select S3 | Served through the configured `FILE_PLUGIN_PUBLIC_ENDPOINT` |
+
+If no storage provider is configured in self-hosted mode and no complete S3 configuration is present, file fields still work in schemas but uploads are disabled. Standalone is different: it enables local file storage by default.
+
+`FILE_PLUGIN_PUBLIC_ENDPOINT` is the exact public URL prefix written to each uploaded file's `url`. Include `/files` in the value if your deployment serves files under `/files`; omit it only when the endpoint itself is the file root. For example, with `FILE_PLUGIN_PUBLIC_ENDPOINT=https://files.example.com/files`, uploaded file metadata contains URLs such as `https://files.example.com/files/<hash>`.
 
 ## File Fields in Schema
 
@@ -25,7 +37,7 @@ Use the File system schema reference (`$ref`) to add a file field. Works at any 
   "title": "Getting Started Guide",
   "slides": [
     {
-      "image": { "status": "uploaded", "fileId": "...", "url": "https://s3.../step1.jpg", "fileName": "step1.jpg", ... },
+      "image": { "status": "uploaded", "fileId": "...", "url": "http://localhost:9222/files/Ua4ZaUehur50VOp2odFvy", "fileName": "step1.jpg", ... },
       "caption": "Step 1: Create a project"
     },
     {
@@ -34,7 +46,7 @@ Use the File system schema reference (`$ref`) to add a file field. Works at any 
     }
   ],
   "branding": {
-    "logo": { "status": "uploaded", "fileId": "...", "url": "https://s3.../logo.svg", "fileName": "logo.svg", ... },
+    "logo": { "status": "uploaded", "fileId": "...", "url": "http://localhost:9222/files/GVke8IlpccUuYaG7pC2rR", "fileName": "logo.svg", ... },
     "color": "#171717"
   }
 }
@@ -88,7 +100,7 @@ The File schema is a pre-defined system schema — you don't need to create it. 
 |-------|------|----------|-------------|
 | `status` | string | yes | `"ready"` (slot created, awaiting upload), `"uploaded"` |
 | `fileId` | string | yes | Unique ID for upload — generated when row is created |
-| `url` | string | yes | S3 URL — populated after upload |
+| `url` | string | yes | Public file URL — populated after upload |
 | `fileName` | string | **no** | Original file name — editable by user |
 | `hash` | string | yes | Content hash (SHA-256) |
 | `extension` | string | yes | File extension (e.g., `"jpg"`, `"pdf"`) |
@@ -132,7 +144,7 @@ File uploaded — metadata populated automatically:
 {
   "status": "uploaded",
   "fileId": "Ua4ZaUehur50VOp2odFvy",
-  "url": "https://s3.../cover.jpg",
+  "url": "http://localhost:9222/files/Ua4ZaUehur50VOp2odFvy",
   "fileName": "cover.jpg",
   "hash": "a1b2c3d4e5...",
   "extension": "jpg",
@@ -152,7 +164,7 @@ New file uploaded to the same slot — metadata updated, same `fileId`:
 {
   "status": "uploaded",
   "fileId": "Ua4ZaUehur50VOp2odFvy",
-  "url": "https://s3.../cover-v2.png",
+  "url": "http://localhost:9222/files/Ua4ZaUehur50VOp2odFvy",
   "fileName": "cover-v2.png",
   "hash": "f6g7h8i9j0...",
   "extension": "png",
@@ -230,7 +242,7 @@ File fields can appear anywhere in your schema:
 **Entire row is a file** — dedicated assets table, each row = one file:
 
 ```json
-{ "status": "uploaded", "fileId": "...", "url": "https://s3.../logo.svg", "fileName": "logo.svg", ... }
+{ "status": "uploaded", "fileId": "...", "url": "http://localhost:9222/files/...", "fileName": "logo.svg", ... }
 ```
 
 **Root array of files** — each row is a gallery:
@@ -287,5 +299,6 @@ The Admin UI includes an Assets view — a gallery of all files across all table
 ## Limits
 
 - Maximum file size: 50 MB (not yet configurable)
-- S3-compatible storage must be configured for file uploads (see [Deployment](../deployment/))
-- Without S3 configured, file fields are available in schemas but upload functionality is disabled
+- Standalone enables local file storage by default under `<data>/uploads`
+- Self-hosted deployments must configure `STORAGE_PROVIDER=local` or complete S3 settings for uploads (see [Deployment](../deployment/))
+- Without a configured storage provider, file fields are available in schemas but upload functionality is disabled

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -13,7 +13,7 @@ Revisium is built on a set of foundational concepts that work together: a hierar
 | [Data Modeling](./data-modeling) | Define field types, nesting, constraints for every table |
 | [Foreign Keys](./foreign-keys) | Referential integrity between tables with cascade operations |
 | [Computed Fields](./computed-fields) | Formula expressions (`x-formula`) with 40+ built-in functions |
-| [Files](./files) | S3 file attachments at any schema level |
+| [Files](./files) | File attachments at any schema level, backed by local or S3-compatible storage |
 | [Versioning & Branches](./versioning) | Draft → commit → HEAD, branches, diff, rollback |
 | [Schema Evolution](./schema-evolution) | Change types, add/remove fields — data transforms automatically |
 | [Platform Hierarchy](./platform-hierarchy) | Organization → Project → Branch → Revision → Table → Row |

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -20,17 +20,24 @@ Open [http://localhost:9222](http://localhost:9222). No auth by default.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--port` | `9222` | HTTP port |
+| `--port` | first free port from `9222` | HTTP port; scans upward until one is free |
+| `--pg-port` | first free port from `5440` | Embedded PostgreSQL port; scans upward until one is free |
 | `--auth` | `false` | Enable authentication (`admin` / `admin`) |
-| `--data` | OS temp dir | Persistent data directory |
+| `--data` | `~/.revisium` | Data directory for embedded PostgreSQL, persisted JWT secret, and default local uploads |
+| `-h`, `--help` | — | Print CLI help |
 
 ```bash
 # Custom port with auth
 npx @revisium/standalone@latest --port 3000 --auth
 
+# Fixed embedded PostgreSQL port
+npx @revisium/standalone@latest --pg-port 5555
+
 # Persistent data
 npx @revisium/standalone@latest --data ./revisium-data
 ```
+
+If the default HTTP or PostgreSQL port is busy, standalone picks the next free port unless you pass a fixed `--port` or `--pg-port`. The supported data-directory option is `--data`; the old accidental `--data-dir` alias is no longer accepted.
 
 MCP endpoint available at `/mcp`:
 
@@ -109,6 +116,8 @@ services:
       CACHE_L2_REDIS_URL: redis://redis:6379
       CACHE_BUS_HOST: redis
       CACHE_BUS_PORT: 6379
+      STORAGE_PROVIDER: s3
+      FILE_PLUGIN_PUBLIC_ENDPOINT: https://files.example.com/files
       S3_ENDPOINT: https://s3.amazonaws.com
       S3_BUCKET: my-revisium-files
       S3_REGION: us-east-1
@@ -218,6 +227,19 @@ All configuration is done via environment variables.
 |----------|---------|-------------|
 | `JWT_SECRET` | auto-generated | JWT signing secret. **Set explicitly in production and multi-pod deployments** |
 | `ADMIN_PASSWORD` | `admin` | Default admin password |
+| `TRUST_PROXY` | unset | Express `trust proxy` value. Required behind ingress, load balancers, or reverse proxies so Express uses forwarded protocol and client IP metadata |
+| `CORS_ORIGIN` | development: reflect request origin; production: same-origin only | Comma-separated credentialed CORS allowlist. Set explicitly when the Admin UI and core API use different origins |
+| `COOKIE_SECURE` | `NODE_ENV === 'production'` | Sets the cookie `Secure` flag. Use `true` for HTTPS deployments |
+| `COOKIE_SAMESITE` | `lax` | Cookie `SameSite` value: `lax`, `strict`, or `none`. `none` requires `COOKIE_SECURE=true` |
+
+Browser login uses cookies, so proxy, CORS, and cookie settings must agree:
+
+| Deployment shape | Recommended values | Notes |
+|------------------|--------------------|-------|
+| Local HTTP | `COOKIE_SECURE=false`, `COOKIE_SAMESITE=lax` | Standalone applies these defaults when `PUBLIC_URL` is local HTTP |
+| Same-site HTTPS | `COOKIE_SECURE=true`, `COOKIE_SAMESITE=lax` or `strict` | Works when Admin UI and API share the same site |
+| HTTPS behind proxy or ingress | `TRUST_PROXY=<hop-count>`, `CORS_ORIGIN=https://your-admin-origin`, `COOKIE_SECURE=true`, `COOKIE_SAMESITE=lax` | Use an explicit CORS allowlist for credentialed browser requests |
+| Cross-site embed or separate site | `COOKIE_SECURE=true`, `COOKIE_SAMESITE=none`, explicit `CORS_ORIGIN` | Browsers reject `SameSite=None` cookies unless they are also `Secure` |
 
 ### Cache
 
@@ -230,15 +252,20 @@ All configuration is done via environment variables.
 | `CACHE_BUS_PORT` | — | Redis port for cache bus |
 | `CACHE_DEBUG` | `0` | Enable cache debug logging |
 
-### S3 (File Storage)
+### File Storage
 
-| Variable | Description |
-|----------|-------------|
-| `S3_ENDPOINT` | S3-compatible endpoint URL |
-| `S3_BUCKET` | Bucket name |
-| `S3_REGION` | AWS region |
-| `S3_ACCESS_KEY_ID` | Access key |
-| `S3_SECRET_ACCESS_KEY` | Secret key |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STORAGE_PROVIDER` | self-hosted: unset; standalone: `local` | Storage backend: `local`, `s3`, or unset. Set `s3` explicitly for S3 deployments, or leave unset only when all `S3_*` variables are present so self-hosted S3 autodetection can select S3; otherwise uploads are disabled |
+| `STORAGE_LOCAL_PATH` | self-hosted: `./uploads`; standalone: `<data>/uploads` | Local filesystem upload directory. In self-hosted mode, `./uploads` is relative to the process working directory |
+| `FILE_PLUGIN_PUBLIC_ENDPOINT` | local: `http://localhost:{PORT}/files`; standalone: `PUBLIC_URL/files` | Exact public URL prefix used in file metadata. Required for S3; include `/files` in the value if your deployment serves files under `/files` |
+| `S3_ENDPOINT` | — | S3-compatible endpoint URL |
+| `S3_BUCKET` | — | Bucket name |
+| `S3_REGION` | — | AWS region |
+| `S3_ACCESS_KEY_ID` | — | Access key |
+| `S3_SECRET_ACCESS_KEY` | — | Secret key |
+
+Standalone stores uploads on the local filesystem by default and serves them from `/files/...`. For Docker, Kubernetes, and multi-pod deployments, use S3-compatible storage unless you intentionally mount shared local storage. Revisium does not append `/files` to an explicit `FILE_PLUGIN_PUBLIC_ENDPOINT`; it uses the value as the URL prefix.
 
 ### SMTP (Email)
 
@@ -253,10 +280,13 @@ All configuration is done via environment variables.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENDPOINT_GRAPHQL_SHOW_NODE_TYPE` | `true` | Generate Node types |
-| `ENDPOINT_GRAPHQL_SHOW_FLAT_TYPE` | `true` | Generate Flat types |
-| `ENDPOINT_GRAPHQL_ADD_PROJECT_PREFIX` | `true` | Prefix types with project name |
-| `ENDPOINT_GRAPHQL_FEDERATION` | `false` | Enable Apollo Federation |
+| `GRAPHQL_HIDE_NODE_TYPES` | `false` | Hide generated GraphQL node query types |
+| `GRAPHQL_HIDE_FLAT_TYPES` | `false` | Hide generated GraphQL flat query types |
+| `GRAPHQL_HIDE_MUTATIONS` | `false` | Hide generated draft-revision GraphQL mutations |
+| `GRAPHQL_PREFIX_FOR_TABLES` | project name | Prefix generated table GraphQL types |
+| `GRAPHQL_PREFIX_FOR_COMMON` | project name | Prefix generated common GraphQL types |
+| `GRAPHQL_FLAT_POSTFIX` | `Flat` | Postfix for flat GraphQL types |
+| `GRAPHQL_NODE_POSTFIX` | empty | Postfix inserted before node type suffixes |
 
 See [API Configuration](../apis/configuration) for details.
 
@@ -302,15 +332,16 @@ Used for L2 cache and multi-pod cache invalidation:
 
 Without Redis, Revisium uses in-memory caching with PostgreSQL-based bus (fine for single-instance). Set `CACHE_ENABLED=1` to enable caching.
 
-### S3 (Optional)
+### File Storage (Optional)
 
-Required for file uploads:
+Revisium supports local filesystem storage and S3-compatible storage:
 
+- Local filesystem storage for standalone or simple single-node deployments
 - Any S3-compatible storage (AWS S3, MinIO, DigitalOcean Spaces, etc.)
 - Files up to 50 MB (not yet configurable)
-- Metadata stored in PostgreSQL, binaries in S3
+- Metadata stored in PostgreSQL, binaries in the configured storage backend
 
-Without S3, file fields are available in schemas but upload is disabled.
+Without `STORAGE_PROVIDER` and without a complete `S3_*` configuration, file fields are available in schemas but upload is disabled.
 
 ### SMTP (Optional)
 
@@ -322,5 +353,5 @@ For email notifications (e.g., user invitations).
 |-----------|----------|-------|
 | PostgreSQL 14+ | Yes | The only required dependency |
 | Node.js 20+ | Standalone/CLI only | Not needed for Docker |
-| S3-compatible storage | Optional | For file uploads |
+| File storage backend | Optional | Standalone uses local storage by default; production deployments usually use S3-compatible storage |
 | Redis | Optional | For caching and multi-pod sync |

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -202,7 +202,9 @@ Read-only fields with `x-formula` expressions — 40+ built-in functions, aggreg
 
 ### Files
 
-S3 file attachments at any schema level — images, documents, galleries. Use embedded file fields directly in your tables, or create a dedicated assets table for reuse. Unopinionated — structure it however fits your project.
+File attachments at any schema level — images, documents, galleries. Use local storage for standalone and simple single-node deployments, or S3-compatible storage for production and multi-node deployments. Embed file fields directly in your tables, or create a dedicated assets table for reuse.
+
+The `fileId` identifies the upload slot; the public `url` is generated from the stored file hash.
 
 <Tabs>
 <TabItem value="data" label="Data" default>
@@ -213,9 +215,9 @@ S3 file attachments at any schema level — images, documents, galleries. Use em
   "cover": {
     "status": "uploaded",
     "fileId": "abc123",
-    "url": "https://s3.../cover.jpg",
+    "url": "http://localhost:9222/files/a1b2c3d4e5f6",
     "fileName": "cover.jpg",
-    "hash": "sha256...",
+    "hash": "a1b2c3d4e5f6...",
     "extension": "jpg",
     "mimeType": "image/jpeg",
     "size": 340000,
@@ -226,9 +228,9 @@ S3 file attachments at any schema level — images, documents, galleries. Use em
     {
       "status": "uploaded",
       "fileId": "def456",
-      "url": "https://s3.../front.jpg",
+      "url": "http://localhost:9222/files/f6e5d4c3b2a1",
       "fileName": "front.jpg",
-      "hash": "sha256...",
+      "hash": "f6e5d4c3b2a1...",
       "extension": "jpg",
       "mimeType": "image/jpeg",
       "size": 280000,
@@ -238,9 +240,9 @@ S3 file attachments at any schema level — images, documents, galleries. Use em
     {
       "status": "uploaded",
       "fileId": "ghi789",
-      "url": "https://s3.../back.jpg",
+      "url": "http://localhost:9222/files/0a1b2c3d4e5f",
       "fileName": "back.jpg",
-      "hash": "sha256...",
+      "hash": "0a1b2c3d4e5f...",
       "extension": "jpg",
       "mimeType": "image/jpeg",
       "size": 310000,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GraphQL configuration: new GRAPHQL_* variables for naming, visibility, postfix/prefix controls, and a GRAPHQL_HIDE_MUTATIONS option.
  * File storage docs now cover configurable providers (local or S3-compatible) and adjusted upload URL examples.
  * Authentication docs replaced JWT guide with detailed browser cookie session flow, refresh/logout, and short-lived token issuance.
  * Deployment/CLI docs clarified port/data options and added proxy/CORS/cookie guidance and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->