### PR TITLE
Remove 'Release Train' workflow section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,26 +66,5 @@ successful build, preview the production bundle with:
 npm run serve
 ```
 
-## Release Train
-
-Use the `Release Train` workflow to plan or publish release-train transitions.
-Dry run mode is enabled by default and does not push branches, commits, tags, or
-releases.
-
-Manual dispatch:
-
-1. Open **Actions** -> **Release Train**.
-2. Select the release transition, for example `start-minor-alpha`.
-3. Keep `dry_run` enabled to inspect the plan, or disable it to publish the
-   release branch and tag.
-4. Run the workflow from `master` for `start-*` transitions, or from the
-   matching `release/X.Y.x` branch for branch-scoped transitions.
-
-Bot dispatch can call the same `workflow_dispatch` endpoint with the `action`
-and `dry_run` inputs. The release-train, CI, and Docker build workflows are
-pinned to `revisium-actions` `v0.3.2` by commit hash `763f2746`.
-
-Write mode requires these repository settings:
-
 - `RELEASE_BOT_CLIENT_ID` as an Actions variable.
 - `RELEASE_BOT_PRIVATE_KEY` as an Actions secret.


### PR DESCRIPTION
Removed the 'Release Train' section detailing the workflow for planning or publishing release-train transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified README by removing Release Train section content while preserving essential repository configuration requirements and environment variable setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->