### PR TITLE
Improve docs intro navigation

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -15,9 +15,37 @@ import TabItem from '@theme/TabItem';
 
 <p className="intro-tagline">Your schema. Your data. Full control.</p>
 
-<p className="intro-usecases">Build your own Headless CMS, Dictionary Service, Configuration Store, AI Agent Memory, Knowledge Base — or anything that needs structured data with integrity. Versioning when you need it.</p>
+<p className="intro-usecases">Revisium is a versioned structured data platform: model data with JSON Schema, edit it in Admin UI, expose it through generated REST and GraphQL APIs, and manage changes with Git-like revisions.</p>
 
-## Key Features
+<div className="intro-route-grid">
+  <a className="intro-route intro-route-primary" href="./quick-start">
+    <span className="intro-route-kicker">Start here</span>
+    <strong>Create a project and explore the workflow</strong>
+    <span>Launch Revisium, model a table, add data, and see how it becomes available through generated APIs.</span>
+  </a>
+  <a className="intro-route" href="./use-cases/">
+    <span className="intro-route-kicker">Choose a use case</span>
+    <strong>CMS, dictionaries, config, AI memory</strong>
+    <span>See practical ways teams use Revisium for structured operational data.</span>
+  </a>
+  <a className="intro-route" href="./core-concepts/">
+    <span className="intro-route-kicker">Understand the model</span>
+    <strong>Schemas, branches, revisions, APIs</strong>
+    <span>Learn the concepts that make Revisium different from a regular CMS or database.</span>
+  </a>
+</div>
+
+## What You Can Build
+
+Use Revisium when your application needs structured data that stays editable, validated, versioned, and available through APIs.
+
+- **Headless CMS** — manage content models, entries, media, and publishing workflows.
+- **Dictionary service** — keep product catalogs, taxonomies, localization keys, and reference data consistent.
+- **Configuration store** — edit operational settings safely, review changes, and promote them across environments.
+- **AI agent memory** — give agents schema-aware storage they can read, update, and commit through MCP.
+- **Internal data platform** — combine Admin UI, generated APIs, and revision history for team-owned data.
+
+## Core Capabilities
 
 ### One Platform, Many Interfaces
 
@@ -570,7 +598,7 @@ Apache 2.0, your infrastructure, no vendor lock-in. Or use [Revisium Cloud](http
 
 ## Next Steps
 
-- **[Quick Start](./quick-start)** — Get Revisium running in under 2 minutes
+- **[Quick Start](./quick-start)** — Create a project and explore generated APIs
 - **[Core Concepts](./core-concepts/)** — Data model, schemas, versioning
 - **[Admin UI](./admin-ui/)** — Visual schema design and data management
 - **[APIs](./apis/)** — System API, generated APIs, MCP

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,7 +9,7 @@ import { ScreenshotRow } from '@site/src/components/Screenshot';
 
 # Quick Start
 
-Get Revisium running and create your first project. This guide uses the Admin UI — you can also do everything via [REST API, GraphQL, or MCP](./apis/).
+Get Revisium running, create a project, model a table, and query it through a generated endpoint. This guide uses the Admin UI — you can also do everything via [REST API, GraphQL, or MCP](./apis/).
 
 ## 1. Start Revisium
 
@@ -179,7 +179,7 @@ Now query your data with a simple curl (example for Standalone on port 9222):
 
 ```bash
 curl -X GET \
-  'http://localhost:9222/endpoint/rest/admin/blog/master/draft/tables/posts/row/hello-world' \
+  'http://localhost:9222/endpoint/rest/admin/blog/master/draft/tables/posts/row/posts-1' \
   -H 'accept: application/json'
 ```
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -269,6 +269,16 @@
   outline-offset: 3px;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .intro-route {
+    transition: none;
+  }
+
+  .intro-route:hover {
+    transform: none;
+  }
+}
+
 .intro-route-primary {
   border-color: #171717;
 }
@@ -302,6 +312,10 @@
   border-color: #525252;
   color: #e5e5e5;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .intro-route:focus-visible {
+  outline-color: #ffffff;
 }
 
 [data-theme="dark"] .intro-route-primary {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -227,11 +227,93 @@
   font-size: 1.05rem;
   color: #737373;
   line-height: 1.7;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
 }
 
 [data-theme="dark"] .intro-usecases {
   color: #737373;
+}
+
+.intro-route-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+.intro-route {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  color: #404040;
+  text-decoration: none !important;
+  background: #ffffff;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.intro-route:hover {
+  border-color: #a3a3a3;
+  color: #171717;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
+}
+
+.intro-route:focus-visible {
+  outline: 2px solid #171717;
+  outline-offset: 3px;
+}
+
+.intro-route-primary {
+  border-color: #171717;
+}
+
+.intro-route-kicker {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #737373;
+}
+
+.intro-route strong {
+  color: #171717;
+  line-height: 1.35;
+}
+
+.intro-route span:last-child {
+  color: #737373;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+[data-theme="dark"] .intro-route {
+  border-color: #262626;
+  color: #a3a3a3;
+  background: #0f0f0f;
+}
+
+[data-theme="dark"] .intro-route:hover {
+  border-color: #525252;
+  color: #e5e5e5;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .intro-route-primary {
+  border-color: #a3a3a3;
+}
+
+[data-theme="dark"] .intro-route strong {
+  color: #f5f5f5;
+}
+
+[data-theme="dark"] .intro-route span:last-child {
+  color: #a3a3a3;
 }
 
 .navbar-search {
@@ -471,5 +553,31 @@ div[class*="codeBlockTitle"] {
 
   .hero__subtitle {
     font-size: 1.05rem;
+  }
+
+  [class*="docMainContainer"] {
+    padding-left: 0 !important;
+  }
+
+  [class*="docItemCol"] {
+    min-width: 0;
+  }
+
+  .markdown {
+    overflow-wrap: break-word;
+  }
+
+  .intro-route-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .intro-route {
+    padding: 0.95rem;
+    transform: none;
+  }
+
+  .intro-route:hover {
+    transform: none;
   }
 }


### PR DESCRIPTION
## Summary
- Add a small routing block to the docs intro so visitors can start with Quick Start, use cases, or core concepts.
- Reframe the intro from a feature list toward a clearer product/use-case overview.
- Make Quick Start wording more factual and align the sample curl row id with the row created earlier in the guide.
- Add light responsive/accessibility styling for the new intro route cards.

## Notes
This is intentionally a small first pass, not a full documentation rewrite. The goal is to make the first page easier to scan and route from, while keeping the existing feature content mostly intact.

## Checks
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an introductory hero section with navigation routes (Start here, Choose a use case, Understand the model).
  * Removed the previous Core Capabilities tagline before Key Features.
  * Updated Quick Start copy to emphasize creating a project and exploring generated APIs; adjusted sample REST endpoint example.

* **Style**
  * Improved responsive design for the intro section and route cards with enhanced mobile layout and interactive card styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->