### PR TITLE
Refine docs landing workflow

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -15,23 +15,30 @@ import TabItem from '@theme/TabItem';
 
 <p className="intro-tagline">Your schema. Your data. Full control.</p>
 
-<p className="intro-usecases">Revisium is a versioned structured data platform: model data with JSON Schema, edit it in Admin UI, expose it through generated REST and GraphQL APIs, and manage changes with Git-like revisions.</p>
+<p className="intro-usecases">Revisium is a versioned structured data platform for teams that need editable, validated data behind generated APIs. Model tables with JSON Schema, work safely in Draft, and commit to HEAD when you want a stable revision to serve.</p>
+
+<div className="intro-workflow-line" aria-label="Revisium workflow">
+  <span>Model data</span>
+  <span>Work in Draft</span>
+  <span>Expose generated APIs</span>
+  <span>Commit to HEAD</span>
+</div>
 
 <div className="intro-route-grid">
   <a className="intro-route intro-route-primary" href="./quick-start">
     <span className="intro-route-kicker">Start here</span>
-    <strong>Create a project and explore the workflow</strong>
-    <span>Launch Revisium, model a table, add data, and see how it becomes available through generated APIs.</span>
+    <strong>Run the Draft-to-API workflow</strong>
+    <span>Create a project, add typed data, and query a generated Draft endpoint.</span>
+  </a>
+  <a className="intro-route" href="./core-concepts/">
+    <span className="intro-route-kicker">Understand the model</span>
+    <strong>Draft, HEAD, branches, revisions</strong>
+    <span>Learn the concepts that make Revisium different from a regular CMS or database.</span>
   </a>
   <a className="intro-route" href="./use-cases/">
     <span className="intro-route-kicker">Choose a use case</span>
     <strong>CMS, dictionaries, config, AI memory</strong>
     <span>See practical ways teams use Revisium for structured operational data.</span>
-  </a>
-  <a className="intro-route" href="./core-concepts/">
-    <span className="intro-route-kicker">Understand the model</span>
-    <strong>Schemas, branches, revisions, APIs</strong>
-    <span>Learn the concepts that make Revisium different from a regular CMS or database.</span>
   </a>
 </div>
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -241,6 +241,33 @@
   margin: 1.5rem 0 2.5rem;
 }
 
+.intro-workflow-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  margin: 1.25rem 0 1.35rem;
+  color: #525252;
+  font-size: 0.88rem;
+}
+
+.intro-workflow-line span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 999px;
+  background: #fafafa;
+  line-height: 1.2;
+}
+
+.intro-workflow-line span:not(:last-child)::after {
+  content: "→";
+  margin-left: 0.45rem;
+  color: #a3a3a3;
+}
+
 .intro-route {
   display: flex;
   flex-direction: column;
@@ -305,6 +332,15 @@
 [data-theme="dark"] .intro-route {
   border-color: #262626;
   color: #a3a3a3;
+  background: #0f0f0f;
+}
+
+[data-theme="dark"] .intro-workflow-line {
+  color: #a3a3a3;
+}
+
+[data-theme="dark"] .intro-workflow-line span {
+  border-color: #262626;
   background: #0f0f0f;
 }
 
@@ -584,6 +620,15 @@ div[class*="codeBlockTitle"] {
   .intro-route-grid {
     grid-template-columns: 1fr;
     gap: 0.75rem;
+  }
+
+  .intro-workflow-line {
+    gap: 0.35rem;
+  }
+
+  .intro-workflow-line span {
+    min-height: 1.8rem;
+    padding: 0.3rem 0.55rem;
   }
 
   .intro-route {


### PR DESCRIPTION
## Summary
- Refine the docs landing page copy around the Revisium Draft-to-API workflow.
- Add a compact workflow line: Model data -> Work in Draft -> Expose generated APIs -> Commit to HEAD.
- Sharpen the top route cards while keeping use cases visible on the first screen.

## Notes
This keeps the change focused on the entry experience. It does not rewrite the broader docs page or change Quick Start content.

## Local checks
- git diff --check
- npm run typecheck
- npm run build
- local production preview `/` returned 200 and included the new workflow markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated intro page copy to better describe the product and its workflow
  * Reorganized route card titles and descriptions
  
* **Style**
  * Enhanced visual workflow styling with responsive design improvements
  * Added dark-mode styling for workflow components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->