### PR TITLE
docs: rebalance structured data positioning

### DIFF
--- a/docs/core-concepts/data-modeling.md
+++ b/docs/core-concepts/data-modeling.md
@@ -22,7 +22,7 @@ Data modeling is the layer that connects the visual Admin UI with runtime APIs.
 | Nested object | Grouped/nested fields in the schema and row editors | Nested response objects and selectable GraphQL projections |
 | Array | Repeatable controls and list-like JSON values | Array response fields, array filtering/sorting support where available |
 | Enum | Constrained values in forms and filters | Enum-like values documented in generated API schemas |
-| `contentMediaType` / `format` | Better editing affordances for markdown, dates, email, and rich text | Stronger validation and clearer API contracts |
+| `contentMediaType` / `format` | Better editing affordances for Markdown, dates, email, and rich text | Stronger validation and clearer API contracts |
 | Default value | New rows start with valid values | Schema evolution can add fields to existing rows safely |
 
 The same model powers several product surfaces:

--- a/docs/core-concepts/data-modeling.md
+++ b/docs/core-concepts/data-modeling.md
@@ -8,7 +8,32 @@ import TabItem from '@theme/TabItem';
 
 # Data Modeling
 
-Every table in Revisium is defined by a JSON Schema. You design the schema — the platform enforces it on every write, generates APIs from it, and transforms data automatically when the schema changes.
+Every table in Revisium is defined by a JSON Schema. You design the schema once — Revisium uses it to render the Admin UI, validate every write, generate APIs, and transform existing data when the schema changes.
+
+Think of a Revisium schema as a product contract for structured data. It describes what editors can change in the UI, what applications can read from generated APIs, and what rules are enforced before data reaches your runtime consumers.
+
+## What Data Modeling Controls
+
+Data modeling is the layer that connects the visual Admin UI with runtime APIs.
+
+| Schema decision | What it changes in the Admin UI | What it changes in APIs |
+|---|---|---|
+| Field name and type | Table columns, row editor controls, inline editing behavior | Generated GraphQL fields, REST/OpenAPI schema, validation errors |
+| Nested object | Grouped/nested fields in the schema and row editors | Nested response objects and selectable GraphQL projections |
+| Array | Repeatable controls and list-like JSON values | Array response fields, array filtering/sorting support where available |
+| Enum | Constrained values in forms and filters | Enum-like values documented in generated API schemas |
+| `contentMediaType` / `format` | Better editing affordances for markdown, dates, email, and rich text | Stronger validation and clearer API contracts |
+| Default value | New rows start with valid values | Schema evolution can add fields to existing rows safely |
+
+The same model powers several product surfaces:
+
+- **Schema Editor** — design table fields and review the resulting JSON Schema.
+- **Table Editor** — scan, filter, sort, resize, hide, and edit data in rows.
+- **Row Editor** — work with one row as a structured form or JSON document.
+- **Generated APIs** — query the same data through GraphQL, REST/OpenAPI, and MCP.
+- **Schema Evolution** — add, remove, move, and change fields while Revisium updates existing rows.
+
+<Screenshot alt="Admin UI — table editor with filtering, nested field columns, and inline editing" src="/img/screenshots/admin-ui-table-editor.png" />
 
 ## Define a Table
 
@@ -49,6 +74,61 @@ A table has a name, a schema (structure), and rows (data). Here's a `products` t
 The schema defines what fields exist, their types, and default values. Any data that doesn't match the schema is rejected.
 
 <Screenshot alt="Schema Editor — products table with field type selector (string, number, boolean, object, array, foreign key, schemas, system fields)" src="/img/screenshots/schema-editor-field-types.png" />
+
+## From Schema To UI
+
+After you create a table, Revisium uses the schema to build editing surfaces automatically.
+
+In the **Schema Editor**, each field is explicit: its type, default value, nested structure, enum values, foreign key, file reference, or computed formula. This makes the model reviewable before data entry starts.
+
+In the **Table Editor**, each row is displayed according to the same schema. Primitive fields can be edited inline, nested fields can be shown as columns, and view settings such as column order, widths, filters, and sorts can be saved for the table.
+
+In the **Row Editor**, the same row becomes a detailed form. This is useful when the data is nested, has long text fields, includes files, or needs careful review before saving.
+
+<Screenshot alt="Row Editor — editing a structured row as a form" src="/img/screenshots/row-page.png" />
+
+## From Schema To APIs
+
+The same schema is also the source for generated API contracts. When a table is exposed through a generated endpoint, Revisium can serve typed data through GraphQL and REST/OpenAPI.
+
+For example, a `products` table can be queried as rows with system fields plus typed `data`:
+
+```graphql
+query {
+  products(data: {
+    first: 10
+    orderBy: [{ data: { path: "price", direction: "desc", type: "float" } }]
+  }) {
+    totalCount
+    edges {
+      node {
+        id
+        data {
+          title
+          price
+          inStock
+        }
+      }
+    }
+  }
+}
+```
+
+That means a schema is not just documentation. It is the source used by editors, validators, generated APIs, and client applications.
+
+## Example Use Cases
+
+The same modeling primitives work across different domains:
+
+| Use case | Example tables | Modeling features |
+|---|---|---|
+| Headless CMS | `pages`, `blog_posts`, `authors`, `navigation` | Markdown strings, file fields, publish dates, author foreign keys |
+| Product catalog | `products`, `categories`, `prices`, `variants` | Nested specs, arrays of variants, enums, computed labels |
+| Game or simulation data | `regions`, `heroes`, `items`, `quests` | Localized strings, foreign keys, embedded arrays, computed fields |
+| Configuration store | `feature_flags`, `plans`, `limits`, `experiments` | Root primitives, structured rules, safe defaults, schema evolution |
+| User-generated workflow data | `form_submissions`, `comments`, `wishlists` | Structured records that admins can review, filter, and process |
+
+The important part is not the domain. The pattern is the same: define the shape once, edit it safely, and serve it through APIs.
 
 ## Field Types
 
@@ -363,6 +443,19 @@ A complete table schema with nested objects and arrays:
 
 <Screenshot alt="Schema Editor — products table with nested specs and variants" src="/img/screenshots/schema-full-example.png" />
 
+## Working With Nested Data In The UI
+
+Nested objects and arrays are useful when a row owns structured details that should stay together.
+
+Examples:
+
+- product `specs` with `weight`, `dimensions`, and `tags`;
+- article `seo` metadata with title, description, and Open Graph image;
+- quest `steps[]` where each step has text, rewards, and completion rules;
+- form submission `answers[]` where each answer stores a field id and value.
+
+In the Admin UI, nested data can be edited in the row form and selected as table columns when the value is useful for scanning. In APIs, the same nested shape is available as JSON/GraphQL fields, so clients can request only the parts they need.
+
 ## Default Values
 
 Primitive fields (string, number, boolean) must have a `default` value. Defaults serve two purposes:
@@ -510,3 +603,5 @@ Data modeling defines the structure. On top of it, you can add:
 - **[Computed Fields](./computed-fields)** — formula-based read-only fields (`x-formula`)
 - **[Files](./files)** — file attachments at any schema level, backed by local or S3-compatible storage
 - **[Schema Evolution](./schema-evolution)** — change types, add/remove fields with automatic data transforms
+- **[Table Editor](../admin-ui/table-editor)** — how modeled data appears as columns, filters, sorts, and saved views
+- **[Generated APIs](../apis/)** — how schemas become GraphQL, REST/OpenAPI, and MCP surfaces

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -13,15 +13,15 @@ import TabItem from '@theme/TabItem';
 
 <h1>Revisium</h1>
 
-<p className="intro-tagline">Your schema. Your data. Full control.</p>
+<p className="intro-tagline">Model any structured data. Serve it through generated APIs.</p>
 
-<p className="intro-usecases">Revisium is a versioned structured data platform for teams that need editable, validated data behind generated APIs. Model tables with JSON Schema, work safely in Draft, and commit to HEAD when you want a stable revision to serve.</p>
+<p className="intro-usecases">Revisium helps teams describe data with JSON Schema, edit it safely in the Admin UI, and expose it to apps, services, and agents through REST, GraphQL, CLI, and MCP. Draft, HEAD, branches, and revisions are the workflow layer for reviewing and publishing changes when you need it.</p>
 
 <div className="intro-workflow-line" aria-label="Revisium workflow">
-  <span>Model data</span>
-  <span>Work in Draft</span>
-  <span>Expose generated APIs</span>
-  <span>Commit to HEAD</span>
+  <span>Model schema</span>
+  <span>Edit structured data</span>
+  <span>Validate every write</span>
+  <span>Use generated APIs</span>
 </div>
 
 <div className="intro-route-grid">
@@ -33,17 +33,17 @@ import TabItem from '@theme/TabItem';
   <a className="intro-route" href="./quick-start">
     <span className="intro-route-kicker">Start here</span>
     <strong>Run the Draft-to-API workflow</strong>
-    <span>Create a project, add typed data, and query a generated Draft endpoint.</span>
+    <span>Create a project, model a table, add data, and query it through a generated endpoint.</span>
   </a>
   <a className="intro-route" href="./core-concepts/">
-    <span className="intro-route-kicker">Understand the model</span>
-    <strong>Draft, HEAD, branches, revisions</strong>
-    <span>Learn the concepts that make Revisium different from a regular CMS or database.</span>
+    <span className="intro-route-kicker">Learn the model</span>
+    <strong>Schemas, tables, APIs, revisions</strong>
+    <span>Learn how Revisium organizes structured data, generated interfaces, and safe change workflows.</span>
   </a>
   <a className="intro-route" href="./use-cases/">
-    <span className="intro-route-kicker">Choose a use case</span>
-    <strong>CMS, dictionaries, config, AI memory</strong>
-    <span>See practical ways teams use Revisium for structured operational data.</span>
+    <span className="intro-route-kicker">Map a use case</span>
+    <strong>CMS, catalogs, config, AI memory</strong>
+    <span>See where Revisium fits in common product and platform workflows.</span>
   </a>
 </div>
 
@@ -51,19 +51,36 @@ import TabItem from '@theme/TabItem';
 Revisium Cloud is currently in Early Access: use it as a hosted sandbox for evaluation and early projects. For production workloads that require full operational control, use self-hosted Docker or Kubernetes.
 :::
 
-## What You Can Build
+## Common Use Cases
 
-Use Revisium when your application needs structured data that stays editable, validated, versioned, and available through APIs.
+Revisium fits best when structured data needs validation, reviewable changes, revision history, and programmatic access.
 
-- **Headless CMS** — manage content models, entries, media, and publishing workflows.
-- **Dictionary service** — keep product catalogs, taxonomies, localization keys, and reference data consistent.
-- **Configuration store** — edit operational settings safely, review changes, and promote them across environments.
-- **AI agent memory** — give agents schema-aware storage they can read, update, and commit through MCP.
-- **Internal data platform** — combine Admin UI, generated APIs, and revision history for team-owned data.
+<div className="intro-usecase-grid">
+  <div className="intro-usecase-card">
+    <strong>Content-backed products</strong>
+    <span>Model pages, entries, media, and localized content without hard-coding every change.</span>
+  </div>
+  <div className="intro-usecase-card">
+    <strong>Catalogs and reference data</strong>
+    <span>Maintain product catalogs, taxonomies, lookup tables, and shared dictionaries with schema validation.</span>
+  </div>
+  <div className="intro-usecase-card">
+    <strong>Operational configuration</strong>
+    <span>Review settings changes before they reach apps, services, or environments.</span>
+  </div>
+  <div className="intro-usecase-card">
+    <strong>Agent-accessible data</strong>
+    <span>Expose schema-aware storage that agents can read and update through MCP.</span>
+  </div>
+  <div className="intro-usecase-card">
+    <strong>Team-owned data workflows</strong>
+    <span>Give non-developers an Admin UI while keeping APIs, revisions, and export paths available for engineers.</span>
+  </div>
+</div>
 
 ## Where Revisium Fits
 
-Revisium acts as a versioned workspace between data operators and runtime consumers. Teams manage change in Draft, then publish a stable HEAD revision through generated APIs.
+Revisium acts as a schema-based workspace between data operators and runtime consumers. Teams model structured data once, edit it through visual or programmatic interfaces, and expose it through generated APIs. Draft, HEAD, branches, and revisions add reviewable change management on top of that model.
 
 <div className="intro-architecture-map-core" role="img" aria-label="Revisium core workspace architecture map">
   <div className="intro-core-side">
@@ -74,14 +91,14 @@ Revisium acts as a versioned workspace between data operators and runtime consum
 
   <div className="intro-core-center">
     <span className="intro-architecture-label">Revisium</span>
-    <strong>Versioned Data Workspace</strong>
+    <strong>Structured Data Workspace</strong>
     <div className="intro-core-lane">
-      <span>Draft workspace</span>
+      <span>JSON Schema model</span>
       <b aria-hidden="true">→</b>
-      <span>HEAD revision</span>
+      <span>Generated APIs</span>
     </div>
     <div className="intro-core-pills">
-      <span>JSON Schema</span>
+      <span>Draft & HEAD</span>
       <span>Relations</span>
       <span>Computed fields</span>
       <span>Files</span>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -350,6 +350,39 @@
   line-height: 1.5;
 }
 
+.intro-usecase-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1.25rem 0 2.5rem;
+}
+
+.intro-usecase-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.intro-usecase-card:last-child {
+  grid-column: 1 / -1;
+}
+
+.intro-usecase-card strong {
+  color: #171717;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.intro-usecase-card span {
+  color: #737373;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
 [data-theme="dark"] .intro-route {
   border-color: #262626;
   color: #a3a3a3;
@@ -384,6 +417,19 @@
 }
 
 [data-theme="dark"] .intro-route span:last-child {
+  color: #a3a3a3;
+}
+
+[data-theme="dark"] .intro-usecase-card {
+  border-color: #262626;
+  background: #0f0f0f;
+}
+
+[data-theme="dark"] .intro-usecase-card strong {
+  color: #f5f5f5;
+}
+
+[data-theme="dark"] .intro-usecase-card span {
   color: #a3a3a3;
 }
 
@@ -834,6 +880,12 @@ div[class*="codeBlockTitle"] {
 
   .intro-route:hover {
     transform: none;
+  }
+
+  .intro-usecase-grid {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+    margin: 1rem 0 2rem;
   }
 
   .intro-architecture-map-core {


### PR DESCRIPTION
## Summary
- reframe the docs entry page around structured data modeling and generated APIs
- keep Draft/HEAD/revisions as workflow mechanics instead of the central slogan
- expand Data Modeling with UI/API behavior, examples, and next-step links

## Validation
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Data Modeling guidance covering schema capabilities, Admin UI and API generation, nested data handling, and practical use cases
  * Refreshed introductory content, navigation structure, and workflow descriptions throughout documentation

* **Style**
  * Added styling for intro use cases section with responsive grid layout and card components, including dark mode support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/docs/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->