### PR TITLE
docs: align quick start with generated APIs flow

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,15 +9,16 @@ import { ScreenshotRow } from '@site/src/components/Screenshot';
 
 # Quick Start
 
-Create a `blog` project, add a typed `posts` table, create a `posts-1` row, and query it through a generated REST Draft endpoint.
+Create a `blog` project, model a typed `posts` table, edit data in the Admin UI, and query it through generated REST and GraphQL APIs.
 
 In this guide, you will:
 
 - start Revisium in Cloud Early Access, Standalone, or Docker
-- model a table and add data in Draft
-- enable a generated REST endpoint
-- query the row with curl or Swagger UI
-- optionally commit the project state to HEAD
+- model structured data as a table schema
+- add rows in the Admin UI draft workspace
+- enable generated Draft REST and GraphQL endpoints
+- query a row and a list of rows with curl or Swagger UI
+- optionally review and commit the project state to HEAD
 
 ## 1. Start Revisium
 
@@ -41,12 +42,14 @@ This is the hosted Early Access sandbox. It is the easiest way to try the workfl
 npx @revisium/standalone@latest
 ```
 
-Open [http://localhost:9222](http://localhost:9222). No auth by default — embedded PostgreSQL, zero configuration.
+Open [http://localhost:9222](http://localhost:9222). No auth by default - embedded PostgreSQL, zero configuration.
 
 To enable authentication:
+
 ```bash
 npx @revisium/standalone@latest --auth
 ```
+
 Login: `admin` / `admin`
 
 </TabItem>
@@ -85,11 +88,11 @@ Open [http://localhost:8080](http://localhost:8080). Login: `admin` / `admin`
 
 ## 2. Open the Admin UI
 
-- **Cloud Early Access:** [cloud.revisium.io](https://cloud.revisium.io) — hosted sandbox; sign in with Google or GitHub
-- **Standalone:** [http://localhost:9222](http://localhost:9222) — no auth by default, with `--auth`: `admin` / `admin`
-- **Docker:** [http://localhost:8080](http://localhost:8080) — login: `admin` / `admin`
+- **Cloud Early Access:** [cloud.revisium.io](https://cloud.revisium.io) - hosted sandbox; sign in with Google or GitHub
+- **Standalone:** [http://localhost:9222](http://localhost:9222) - no auth by default, with `--auth`: `admin` / `admin`
+- **Docker:** [http://localhost:8080](http://localhost:8080) - login: `admin` / `admin`
 
-<Screenshot alt="Revisium Admin UI — empty project list after first launch" src="/img/screenshots/empty-project-list.png" />
+<Screenshot alt="Revisium Admin UI - empty project list after first launch" src="/img/screenshots/empty-project-list.png" />
 
 ## 3. Create a Project
 
@@ -97,84 +100,89 @@ Open [http://localhost:8080](http://localhost:8080). Login: `admin` / `admin`
 2. Enter a name (e.g., `blog`)
 3. You'll land on the default `master` branch with an empty draft revision
 
-<Screenshot alt="Create Project — entering project name" src="/img/screenshots/create-project.png" />
+<Screenshot alt="Create Project - entering project name" src="/img/screenshots/create-project.png" />
 
 ## 4. Design a Schema
 
+In Revisium, the schema is the contract behind both the table editor and the generated API. Field names, types, defaults, and formats define what editors see in the Admin UI and what clients can query later.
+
 1. Click **New Table** and name it `posts`
 2. In the Schema Editor, add fields:
-   - `title` — String
-   - `content` — String (format: markdown)
-   - `published` — Boolean (default: false)
-3. Click **Create Table** — a review dialog will show the schema and data preview
+   - `title` - String
+   - `content` - String (format: Markdown)
+   - `published` - Boolean (default: false)
+3. Click **Create Table** - a review dialog will show the schema and data preview
 4. Confirm to create the table
 
-<Screenshot alt="Schema Editor — creating posts table with title, content, and published fields" src="/img/screenshots/schema-editor-create-table.png" />
+<Screenshot alt="Schema Editor - creating posts table with title, content, and published fields" src="/img/screenshots/schema-editor-create-table.png" />
 
 <ScreenshotRow>
-  <Screenshot alt="Create Table review — Example data preview" src="/img/screenshots/create-table-example.png" />
-  <Screenshot alt="Create Table review — JSON Schema" src="/img/screenshots/create-table-schema.png" />
+  <Screenshot alt="Create Table review - Example data preview" src="/img/screenshots/create-table-example.png" />
+  <Screenshot alt="Create Table review - JSON Schema" src="/img/screenshots/create-table-schema.png" />
 </ScreenshotRow>
 
 ## 5. Add Content
 
 After creating the table, the Table Editor opens automatically (or select the table from the list in **Database**).
 
-<Screenshot alt="Empty posts table — ready to add rows" src="/img/screenshots/table-empty.png" />
+<Screenshot alt="Empty posts table - ready to add rows" src="/img/screenshots/table-empty.png" />
 
 1. Click **+** in the header to create a new row
-2. Enter a row id (e.g., `posts-1`) — you can rename it later
+2. Enter a row id (e.g., `posts-1`) - you can rename it later
 3. Fill in the fields, then confirm:
    - `title`: `Example post`
    - `content`: `Hello from Revisium`
    - `published`: `false`
 
-<Screenshot alt="Creating a new row — filling in title, content, and published fields" src="/img/screenshots/row-editor-create.png" />
+<Screenshot alt="Creating a new row - filling in title, content, and published fields" src="/img/screenshots/row-editor-create.png" />
 
-The row appears in the table. You can edit values directly in cells by clicking on them.
+The row appears in the table. The same schema that defined the API contract now drives editable columns in the Admin UI. You can edit values directly in cells by clicking on them.
 
-<Screenshot alt="Table with a row — content cell selected for inline editing" src="/img/screenshots/table-with-row.png" />
+<Screenshot alt="Table with a row - content cell selected for inline editing" src="/img/screenshots/table-with-row.png" />
 
 To open the full Row Editor page, hover over the row id and click **Open** from the menu (or use the arrow icon).
 
 <ScreenshotRow>
-  <Screenshot alt="Row context menu — Open, Select, Duplicate, Delete" src="/img/screenshots/table-row-menu.png" />
-  <Screenshot alt="Row Editor page — full view of the record" src="/img/screenshots/row-page.png" />
+  <Screenshot alt="Row context menu - Open, Select, Duplicate, Delete" src="/img/screenshots/table-row-menu.png" />
+  <Screenshot alt="Row Editor page - full view of the record" src="/img/screenshots/row-page.png" />
 </ScreenshotRow>
 
-## 6. Create an API Endpoint
+## 6. Create API Endpoints
 
 1. Expand the **Management** section in the sidebar and click **Endpoints**
-2. Select the **REST API** tab (or GraphQL)
-3. Toggle on **Draft**. You can also enable **Head** if you want to try the optional commit step later.
+2. Select the **REST API** tab and toggle on **Draft**
+3. Select the **GraphQL** tab and toggle on **Draft** if you also want to inspect the generated GraphQL schema
+4. You can enable **Head** later if you want to compare Draft with the committed revision
 
-<Screenshot alt="Endpoints page — REST API tab with Draft and Head toggles off" src="/img/screenshots/endpoints-off.png" />
+<Screenshot alt="Endpoints page - REST API tab with Draft and Head toggles off" src="/img/screenshots/endpoints-off.png" />
 
-Once enabled, hover over an endpoint to copy its URL or open the Swagger UI.
+Endpoints are configured at the project level. The URL still includes the organization, project, branch, and target revision, for example `admin/blog/master/draft`.
 
-- **Head** — serves the latest committed revision (read-only, for production)
-- **Draft** — serves the current working state (includes uncommitted changes, for preview)
+Once REST is enabled, hover over an endpoint to copy its URL or open the Swagger UI.
 
-<Screenshot alt="Endpoints enabled — Draft and Head toggles on, with copy URL and Swagger buttons" src="/img/screenshots/endpoints-on.png" />
+- **Draft** - serves the current working state, including uncommitted changes, for preview
+- **Head** - serves the latest committed revision, for stable read access
 
-Click the **code icon** (`</>`) to open the Swagger UI. Notice how HEAD shows only committed state, while Draft includes uncommitted changes:
+<Screenshot alt="Endpoints enabled - Draft and Head toggles on, with copy URL and Swagger buttons" src="/img/screenshots/endpoints-on.png" />
+
+Click the **code icon** (`</>`) to open the Swagger UI. If both Draft and Head are enabled, you can compare the current draft with the latest committed state:
 
 <ScreenshotRow>
-  <Screenshot alt="Swagger HEAD — posts table only (committed data)" src="/img/screenshots/swagger-head.png" />
-  <Screenshot alt="Swagger Draft — endpoint documentation showing uncommitted draft changes" src="/img/screenshots/swagger-draft.png" />
+  <Screenshot alt="Swagger HEAD - posts table only (committed data)" src="/img/screenshots/swagger-head.png" />
+  <Screenshot alt="Swagger Draft - endpoint documentation showing uncommitted draft changes" src="/img/screenshots/swagger-draft.png" />
 </ScreenshotRow>
 
 ## 7. Query Your Data
 
-By default, endpoints require authentication. To make read queries work without a token (convenient for testing), go to **Management → Settings** and set visibility to **Public**.
+By default, endpoints require authentication. To make read queries work without a token (convenient for testing), go to **Management -> Settings** and change visibility from **Private** to **Public**.
 
 :::warning
 Use public visibility only for local testing, public content, or controlled preview scenarios. For private or production data, keep the project private and use API keys or another supported authentication method.
 :::
 
-<Screenshot alt="Settings — switching project visibility to Public for unauthenticated read access" src="/img/screenshots/settings-public.png" />
+<Screenshot alt="Project Settings - visibility control before switching the project to Public" src="/img/screenshots/settings-public.png" />
 
-Now query your data with a simple curl. This example uses the Standalone endpoint on port `9222`; for Cloud or Docker, copy the endpoint URL from the Admin UI.
+Now query a single row with curl. This example uses the Standalone endpoint on port `9222`; for Cloud or Docker, copy the endpoint URL from the Admin UI.
 
 ```bash
 curl -X GET \
@@ -182,7 +190,7 @@ curl -X GET \
   -H 'accept: application/json'
 ```
 
-Expected response shape (timestamps and metadata will vary):
+Expected response shape (ids, timestamps, and metadata will vary):
 
 ```json
 {
@@ -198,30 +206,90 @@ Expected response shape (timestamps and metadata will vary):
 }
 ```
 
-Or use the Swagger UI — click **Try it out**, execute, and see the response:
+To query a list of rows, use the generated REST list operation. OpenAPI describes this as `POST /tables/{tableId}/rows` with filtering, sorting, and pagination in the request body.
 
-<Screenshot alt="Swagger UI — GET request to posts/row/posts-1 with full JSON response" src="/img/screenshots/swagger-response.png" />
+```bash
+curl -X POST \
+  'http://localhost:9222/endpoint/rest/admin/blog/master/draft/tables/posts/rows' \
+  -H 'accept: application/json' \
+  -H 'content-type: application/json' \
+  -d '{ "first": 10 }'
+```
 
-## 8. Optional: Commit Changes and Use HEAD
+Expected response shape:
+
+```json
+{
+  "pageInfo": {
+    "hasNextPage": false,
+    "hasPreviousPage": false
+  },
+  "totalCount": 1,
+  "edges": [
+    {
+      "node": {
+        "id": "posts-1",
+        "data": {
+          "title": "Example post",
+          "content": "Hello from Revisium",
+          "published": false
+        }
+      }
+    }
+  ]
+}
+```
+
+If you enabled GraphQL Draft as well, query the same row through the generated GraphQL API:
+
+```bash
+curl -X POST \
+  'http://localhost:9222/endpoint/graphql/admin/blog/master/draft' \
+  -H 'content-type: application/json' \
+  -d '{ "query": "{ posts(id: \"posts-1\") { id data { title content published } } }" }'
+```
+
+Expected GraphQL response shape:
+
+```json
+{
+  "data": {
+    "posts": {
+      "id": "posts-1",
+      "data": {
+        "title": "Example post",
+        "content": "Hello from Revisium",
+        "published": false
+      }
+    }
+  }
+}
+```
+
+Or use the Swagger UI - click **Try it out**, execute, and see the response:
+
+<Screenshot alt="Swagger UI - GET request to posts/row/posts-1 with full JSON response" src="/img/screenshots/swagger-response.png" />
+
+## 8. Optional: Review, Commit, and Use HEAD
 
 Draft endpoints update as you edit data. Commit when you want the current project state to become an immutable HEAD revision for stable, read-only access.
 
-You can commit directly from the sidebar — click the **checkmark** next to the branch name, add an optional comment, and click **Commit**.
+You can commit directly from the sidebar - click the **checkmark** next to the branch name, add an optional comment, and click **Commit**.
 
-<Screenshot alt="Commit from sidebar — optional comment and Commit button" src="/img/screenshots/commit-sidebar.png" />
+<Screenshot alt="Commit from sidebar - optional comment and Commit button" src="/img/screenshots/commit-sidebar.png" />
 
 To review changes before committing, go to **Changes** in the sidebar. The **Tables** tab shows added/modified tables, the **Row Changes** tab shows individual row diffs.
 
 <ScreenshotRow>
-  <Screenshot alt="Changes — Tables tab showing posts Added, system tables Modified" src="/img/screenshots/changes-tables.png" />
-  <Screenshot alt="Changes — Row Changes tab with search and filter" src="/img/screenshots/changes-rows.png" />
+  <Screenshot alt="Changes - Tables tab showing posts Added, system tables Modified" src="/img/screenshots/changes-tables.png" />
+  <Screenshot alt="Changes - Row Changes tab with search and filter" src="/img/screenshots/changes-rows.png" />
 </ScreenshotRow>
 
 Click any row change to see the field-level diff. Then click **Commit** in the top right and enter an optional comment.
 
 <ScreenshotRow>
-  <Screenshot alt="Row change detail — field-level diff showing added data" src="/img/screenshots/changes-row-detail.png" />
-  <Screenshot alt="Commit dialog — entering comment and confirming" src="/img/screenshots/commit-dialog.png" />
+  <Screenshot alt="Row change detail - field-level diff showing added data" src="/img/screenshots/changes-row-detail.png" />
+  <Screenshot alt="Commit dialog - entering comment and confirming" src="/img/screenshots/commit-dialog.png" />
 </ScreenshotRow>
 
 After committing, the draft resets and a new immutable revision becomes HEAD. HEAD endpoints serve the latest committed revision; Draft endpoints continue to serve the current working state.
@@ -230,15 +298,16 @@ After committing, the draft resets and a new immutable revision becomes HEAD. HE
 
 You now have a working Revisium project with:
 
-- A `posts` table with typed schema (title, content, published)
-- Data rows accessible via auto-generated REST and GraphQL APIs
-- Version history (if you committed) with rollback capability
-- HEAD and Draft endpoints serving different states of your data
+- a `posts` table with typed schema (`title`, `content`, `published`)
+- rows editable through the Admin UI
+- data accessible through auto-generated REST and GraphQL APIs
+- optional review and commit workflow for publishing a stable HEAD revision
+- HEAD and Draft endpoints for different states of your data
 
 ## Next Steps
 
-- **[Platform Hierarchy](./core-concepts/platform-hierarchy)** — Organizations, projects, branches, and revisions
-- **[Data Modeling](./core-concepts/data-modeling)** — Field types, nesting, and constraints
-- **[Foreign Keys](./core-concepts/foreign-keys)** — Relationships between tables
-- **[Querying Data](./querying-data/)** — Filtering, sorting, pagination
-- **[Deployment](./deployment/)** — Production setup with Docker or Kubernetes
+- **[Platform Hierarchy](./core-concepts/platform-hierarchy)** - Organizations, projects, branches, and revisions
+- **[Data Modeling](./core-concepts/data-modeling)** - Field types, nesting, and constraints
+- **[Foreign Keys](./core-concepts/foreign-keys)** - Relationships between tables
+- **[Querying Data](./querying-data/)** - Filtering, sorting, pagination
+- **[Deployment](./deployment/)** - Production setup with Docker or Kubernetes


### PR DESCRIPTION
## Summary

- Reworked Quick Start around the structured-data flow: schema -> Admin UI editing -> generated APIs.
- Added REST list-query example based on the generated OpenAPI route.
- Added GraphQL Draft endpoint setup and a real row query example.
- Kept Review/Commit/HEAD as an optional publishing workflow instead of the main walkthrough goal.
- Cleaned up broken punctuation/encoding artifacts in the page.

## Notes

This is a follow-up to #53 and uses the same positioning direction: generated APIs and schema-driven data modeling are the first proof point, while Draft/HEAD remains the review/publish workflow layer.

The branch is intentionally stacked on `docs/landing-entry-blocks-review` so the PR only shows the Quick Start changes.

## Test

- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start guide with a refined workflow emphasizing typed table creation and data querying.
  * Added concrete REST and GraphQL query examples with expected responses for better clarity.
  * Enhanced Admin UI walkthrough with expanded environment-specific guidance and streamlined schema steps.
  * Included authentication setup options and guidance for unauthenticated read access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/docs/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->