### PR TITLE
ci: validate docs build in pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
   checks:
     uses: revisium/revisium-actions/.github/workflows/node-build.yml@763f2746000f15842e642130dba3acf09c5d00ac # v0.3.2
     with:
-      node_version: 22.11.0
+      node_version: 22.16.0
       install_command: npm ci
-      run_commands: npm run typecheck
+      run_commands: |
+        npm run typecheck
+        npm run build
 
   sonar:
     needs: checks

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -40,7 +40,7 @@ jobs:
       action: ${{ inputs.action }}
       dry_run: ${{ inputs.dry_run }}
       base_branch: master
-      node_version: 22.11.0
+      node_version: 22.16.0
       install_command: npm ci
       validate_command: |
         npm run typecheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.11.0-alpine AS builder
+FROM node:22.16.0-alpine AS builder
 
 WORKDIR /home/app
 


### PR DESCRIPTION
## Summary
Improve docs build reliability and environment consistency.

Changes:
- align CI/release/Docker Node version with documented `.nvmrc` / README version (`22.16.0`)
- run `npm run build` in PR CI checks in addition to typecheck
- ensure docs build regressions (broken links / Docusaurus config issues) are caught before merge

## Validation
- npm run typecheck
- npm run build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version to 22.16.0 across CI/CD pipelines and containerized builds to leverage the latest stable improvements and bug fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/docs/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->